### PR TITLE
Added context menu on note view which allows toggle displaying thumbnail

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ set(${PROJECT_NAME}_HEADERS
     src/insert-table-tool-button/TableSizeSelector.h
     src/utility/ColorCodeValidator.h
     src/utility/StartAtLogin.h
+    src/utility/ApplicationSettingsUtil.h
     src/views/ItemView.h
     src/views/DeletedNoteItemView.h
     src/views/FavoriteItemView.h
@@ -249,6 +250,7 @@ set(${PROJECT_NAME}_SOURCES
     src/delegates/TagItemDelegate.cpp
     src/utility/ColorCodeValidator.cpp
     src/utility/StartAtLogin.cpp
+    src/utility/ApplicationSettingsUtil.cpp
     src/views/ItemView.cpp
     src/views/DeletedNoteItemView.cpp
     src/views/FavoriteItemView.cpp

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -227,6 +227,7 @@ private Q_SLOTS:
     void onNoteSortingModeChanged(int index);
     void onNewNoteCreationRequested();
     void onCopyInAppLinkNoteRequested(QString noteLocalUid, QString noteGuid);
+    void onToggleThumbnailsPreference();
 
     void onNoteModelAllNotesListed();
 
@@ -251,7 +252,7 @@ private Q_SLOTS:
 
     // Preferences dialog slots
     void onUseLimitedFontsPreferenceChanged(bool flag);
-    void onShowNoteThumbnailsPreferenceChanged(bool flag);
+    void onShowNoteThumbnailsPreferenceChanged();
     void onRunSyncEachNumMinitesPreferenceChanged(int runSyncEachNumMinutes);
 
     // Note search-related slots
@@ -455,6 +456,8 @@ private:
 
     bool isInsideStyleBlock(const QString & styleSheet, const QString & styleBlockStartSearchString,
                             const int currentIndex, bool & error) const;
+
+    bool                    getShowNoteThumbnails() const;
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
     // Qt4 has a problem with zero-size QSplitter handles - they don't work that way.

--- a/src/dialogs/PreferencesDialog.cpp
+++ b/src/dialogs/PreferencesDialog.cpp
@@ -31,6 +31,7 @@ using quentier::ShortcutSettingsWidget;
 #include "../MainWindowSideBorderOption.h"
 #include "../utility/ColorCodeValidator.h"
 #include "../utility/StartAtLogin.h"
+#include "../utility/ApplicationSettingsUtil.h"
 #include <quentier/logging/QuentierLogger.h>
 #include <quentier/utility/ApplicationSettings.h>
 #include <quentier/utility/ShortcutManager.h>
@@ -225,13 +226,10 @@ void PreferencesDialog::onShowNoteThumbnailsCheckboxToggled(bool checked)
     QNDEBUG(QStringLiteral("PreferencesDialog::onShowNoteThumbnailsCheckboxToggled: checked = ")
             << (checked ? QStringLiteral("checked") : QStringLiteral("unchecked")));
 
-    Account currentAccount = m_accountManager.currentAccount();
-    ApplicationSettings appSettings(currentAccount, QUENTIER_UI_SETTINGS);
-    appSettings.beginGroup(LOOK_AND_FEEL_SETTINGS_GROUP_NAME);
-    appSettings.setValue(SHOW_NOTE_THUMBNAILS_SETTINGS_KEY, checked);
-    appSettings.endGroup();
+    setApplicationSetting(m_accountManager.currentAccount(), QUENTIER_UI_SETTINGS, LOOK_AND_FEEL_SETTINGS_GROUP_NAME,
+                          SHOW_NOTE_THUMBNAILS_SETTINGS_KEY, QVariant::fromValue(checked));
 
-    Q_EMIT showNoteThumbnailsOptionChanged(checked);
+    Q_EMIT showNoteThumbnailsOptionChanged();
 }
 
 void PreferencesDialog::onShowMainWindowLeftBorderOptionChanged(int option)
@@ -553,7 +551,6 @@ void PreferencesDialog::setupCurrentSettingsState(ActionsInfo & actionsInfo, Sho
     setupSystemTraySettings();
 
     // 2) Note editor tab
-
     Account currentAccount = m_accountManager.currentAccount();
     ApplicationSettings appSettings(currentAccount, QUENTIER_UI_SETTINGS);
 
@@ -564,17 +561,10 @@ void PreferencesDialog::setupCurrentSettingsState(ActionsInfo & actionsInfo, Sho
     m_pUi->limitedFontsCheckBox->setChecked(useLimitedFonts);
 
     // 3) Appearance tab
-
-    appSettings.beginGroup(LOOK_AND_FEEL_SETTINGS_GROUP_NAME);
-
-    bool showNoteThumbnails = DEFAULT_SHOW_NOTE_THUMBNAILS;
-    if (appSettings.contains(SHOW_NOTE_THUMBNAILS_SETTINGS_KEY)) {
-        showNoteThumbnails = appSettings.value(SHOW_NOTE_THUMBNAILS_SETTINGS_KEY).toBool();
-    }
-
-    appSettings.endGroup();
-
-    m_pUi->showNoteThumbnailsCheckBox->setChecked(showNoteThumbnails);
+    QVariant showThumbnails = getApplicationSetting(
+        appSettings, LOOK_AND_FEEL_SETTINGS_GROUP_NAME, SHOW_NOTE_THUMBNAILS_SETTINGS_KEY,
+        QVariant::fromValue(DEFAULT_SHOW_NOTE_THUMBNAILS));
+    m_pUi->showNoteThumbnailsCheckBox->setChecked(showThumbnails.toBool());
 
     setupMainWindowBorderSettings();
 
@@ -582,7 +572,6 @@ void PreferencesDialog::setupCurrentSettingsState(ActionsInfo & actionsInfo, Sho
     setupStartAtLoginSettings();
 
     // 5) Synchronization tab
-
     if (currentAccount.type() == Account::Type::Local)
     {
         // Remove the synchronization tab entirely

--- a/src/dialogs/PreferencesDialog.h
+++ b/src/dialogs/PreferencesDialog.h
@@ -50,7 +50,7 @@ Q_SIGNALS:
     void noteEditorUseLimitedFontsOptionChanged(bool enabled);
     void synchronizationDownloadNoteThumbnailsOptionChanged(bool enabled);
     void synchronizationDownloadInkNoteImagesOptionChanged(bool enabled);
-    void showNoteThumbnailsOptionChanged(bool enabled);
+    void showNoteThumbnailsOptionChanged();
     void runSyncPeriodicallyOptionChanged(int runSyncEachNumMinutes);
 
     void showMainWindowLeftBorderOptionChanged(int option);

--- a/src/models/NotebookModel.cpp
+++ b/src/models/NotebookModel.cpp
@@ -4080,7 +4080,8 @@ const NotebookModelItem & NotebookModel::findOrCreateLinkedNotebookModelItem(con
 
 const NotebookModelItem * NotebookModel::itemForId(const IndexId id) const
 {
-    QNDEBUG(QStringLiteral("NotebookModelItem * NotebookModel::itemForId: ") << id);
+    // this is called too often to be DEBUG level
+    QNTRACE(QStringLiteral("NotebookModelItem * NotebookModel::itemForId: ") << id);
 
     auto localUidIt = m_indexIdToLocalUidBimap.left.find(id);
     if (localUidIt != m_indexIdToLocalUidBimap.left.end())

--- a/src/utility/ApplicationSettingsUtil.cpp
+++ b/src/utility/ApplicationSettingsUtil.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 Dmitry Ivanov
+ *
+ * This file is part of Quentier.
+ *
+ * Quentier is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * Quentier is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Quentier. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ApplicationSettingsUtil.h"
+#include <quentier/utility/ApplicationSettings.h>
+#include <quentier/logging/QuentierLogger.h>
+
+namespace quentier {
+
+QVariant getApplicationSetting(
+    ApplicationSettings & appSettings,
+    const QString & settingsGroup,
+    const QString & settingsKey,
+    const QVariant & defaultValue)
+{
+    QVariant ret = defaultValue;
+    appSettings.beginGroup(settingsGroup);
+    if (appSettings.contains(settingsKey)) {
+        ret = appSettings.value(settingsKey);
+    }
+    appSettings.endGroup();
+    return ret;
+}
+
+
+QVariant getApplicationSetting(
+    const Account & account,
+    const QString & settingsName,
+    const QString & settingsGroup,
+    const QString & settingsKey,
+    const QVariant & defaultValue)
+{
+    QNTRACE(QStringLiteral("getApplicationSetting"));
+
+    ApplicationSettings appSettings(account, settingsName);
+    return getApplicationSetting(appSettings, settingsGroup, settingsKey, defaultValue);
+}
+
+void setApplicationSetting(
+    const Account & account,
+    const QString & settingsName,
+    const QString & settingsGroup,
+    const QString & settingsKey,
+    const QVariant & value) {
+    ApplicationSettings appSettings(account, settingsName);
+    appSettings.beginGroup(settingsGroup);
+    appSettings.setValue(settingsKey, value);
+    appSettings.endGroup();
+}
+
+} // namespace quentier

--- a/src/utility/ApplicationSettingsUtil.h
+++ b/src/utility/ApplicationSettingsUtil.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 Dmitry Ivanov
+ *
+ * This file is part of Quentier.
+ *
+ * Quentier is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * Quentier is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Quentier. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef QUENTIER_UTILITY_APPLICATION_SETTINGS_UTIL_H
+#define QUENTIER_UTILITY_APPLICATION_SETTINGS_UTIL_H
+
+#include <quentier/utility/ApplicationSettings.h>
+
+
+namespace quentier {
+
+
+// helpers to avoid duplicating code when accessing settings
+// could be later moved directly to ApplicationSettings
+
+/**
+ * Get application setting.
+ *
+ * @param account Current account.
+ * @param settingsName Settings name.
+ * @param settingsGroup Group name.
+ * @param settingsKey Key name.
+ * @param defaultValue Default value.
+ * @return Settings value (or default if it was not set before).
+ */
+QVariant getApplicationSetting(
+    const Account & account,
+    const QString & settingsName,
+    const QString & settingsGroup,
+    const QString & settingsKey,
+    const QVariant & defaultValue);
+
+/**
+ * Get application setting.
+ *
+ * @param appSettings Setting instance.
+ * @param settingsGroup Group name.
+ * @param settingsKey Key name.
+ * @param defaultValue Default value.
+ * @return Settings value (or default if it was not set before).
+ */
+QVariant getApplicationSetting(
+    ApplicationSettings & appSettings,
+    const QString & settingsGroup,
+    const QString & settingsKey,
+    const QVariant & defaultValue);
+
+
+
+/**
+ * Set application setting.
+ *
+ * @param account Current account.
+ * @param settingsName Settings name.
+ * @param settingsGroup Group name.
+ * @param settingsKey Key name.
+ * @param value Value to set.
+ */
+void setApplicationSetting(
+    const Account &account,
+    const QString &settingsName,
+    const QString &settingsGroup,
+    const QString &settingsKey,
+    const QVariant &value);
+
+} // namespace quentier
+
+#endif // QUENTIER_UTILITY_APPLICATION_SETTINGS_UTIL_H

--- a/src/views/NoteListView.cpp
+++ b/src/views/NoteListView.cpp
@@ -485,6 +485,14 @@ void NoteListView::onShowNoteInfoAction()
     Q_EMIT noteInfoDialogRequested(noteLocalUid);
 }
 
+
+void NoteListView::onToggleThumbnailsPreference()
+{
+    QNDEBUG(QStringLiteral("NoteListView::onToggleThumbnailsPreference"));
+
+    Q_EMIT toggleThumbnailsPreference();
+}
+
 void NoteListView::onCopyInAppNoteLinkAction()
 {
     QNDEBUG(QStringLiteral("NoteListView::onCopyInAppNoteLinkAction"));
@@ -837,6 +845,9 @@ void NoteListView::showSingleNoteContextMenu(const QPoint & pos, const QPoint & 
         ADD_CONTEXT_MENU_ACTION(tr("Copy in-app note link"), m_pNoteItemContextMenu,
                                 onCopyInAppNoteLinkAction, localUidAndGuid, true);
     }
+
+    QMenu * pThumbnailsSubMenu = m_pNoteItemContextMenu->addMenu(tr("Thumbnails"));
+    ADD_CONTEXT_MENU_ACTION(tr("Toggle all"), pThumbnailsSubMenu, onToggleThumbnailsPreference, QVariant(), true);
 
     m_pNoteItemContextMenu->show();
     m_pNoteItemContextMenu->exec(globalPos);

--- a/src/views/NoteListView.h
+++ b/src/views/NoteListView.h
@@ -82,6 +82,8 @@ Q_SIGNALS:
 
     void enexExportRequested(QStringList noteLocalUids);
 
+    void toggleThumbnailsPreference();
+
 public Q_SLOTS:
     /**
      * The slot which can watch for external changes of current note
@@ -122,6 +124,9 @@ protected Q_SLOTS:
 
     void onShowNoteInfoAction();
     void onCopyInAppNoteLinkAction();
+
+    void onToggleThumbnailsPreference();
+
 
     void onExportSingleNoteToEnexAction();
     void onExportSeveralNotesToEnexAction();


### PR DESCRIPTION
First part of the solution of #164
I did a bit more simpler version, which is called "Toggle all" and toggles the current setting.
The second part would be "Toggle current" - which should toggle the thumbnail display for current note (will be in next PR).
It could be done that the menu actually changes with the action, but I don't think this function is so important, to be worth more time now. And it can be improved later.

The ApplicationSettingsUtil is some effort to avoid so much code duplication when reading/setting settings. Its not yet perfect, but I consider it improvement.
![screen_20180720_13](https://user-images.githubusercontent.com/1135218/43017557-d4334482-8c56-11e8-8a06-ef6e0d3262c8.png)

