### PR TITLE
Improvements in log verbosity adjustments

### DIFF
--- a/src/AccountManager.cpp
+++ b/src/AccountManager.cpp
@@ -109,7 +109,7 @@ void AccountManager::raiseManageAccountsDialog()
 
 void AccountManager::switchAccount(const Account & account)
 {
-    QNDEBUG(QStringLiteral("AccountManager::switchAccount: ") << account);
+    QNDEBUG(QStringLiteral("AccountManager::switchAccount: ") << account.name());
 
     // See whether this account is within a list of already available accounts, if not, add it there
     bool accountIsAvailable = false;
@@ -192,7 +192,7 @@ void AccountManager::onLocalAccountAdditionRequested(QString name, QString fullN
 
 void AccountManager::onAccountDisplayNameChanged(Account account)
 {
-    QNDEBUG(QStringLiteral("AccountManager::onAccountDisplayNameChanged: ") << account);
+    QNDEBUG(QStringLiteral("AccountManager::onAccountDisplayNameChanged: ") << account.name());
 
     int index = m_availableAccounts.indexOf(account);
     if (Q_UNLIKELY(index < 0)) {
@@ -381,7 +381,7 @@ QSharedPointer<Account> AccountManager::createLocalAccount(const QString & name,
 
 bool AccountManager::createAccountInfo(const Account & account)
 {
-    QNDEBUG(QStringLiteral("AccountManager::createAccountInfo: ") << account);
+    QNDEBUG(QStringLiteral("AccountManager::createAccountInfo: ") << account.name());
 
     bool isLocal = (account.type() == Account::Type::Local);
 
@@ -517,21 +517,21 @@ QString AccountManager::evernoteAccountTypeToString(const Account::EvernoteAccou
 
 void AccountManager::readComplementaryAccountInfo(Account & account)
 {
-    QNDEBUG(QStringLiteral("AccountManager::readComplementaryAccountInfo: ") << account);
+    QNTRACE(QStringLiteral("AccountManager::readComplementaryAccountInfo: ") << account.name());
 
     if (Q_UNLIKELY(account.isEmpty())) {
-        QNDEBUG(QStringLiteral("The account is empty"));
+        QNDEBUG(QStringLiteral("The account is empty ") << account.name());
         return;
     }
 
     if (Q_UNLIKELY(account.name().isEmpty())) {
-        QNDEBUG(QStringLiteral("The account name is empty"));
+        QNDEBUG(QStringLiteral("The account name is empty ") << account.name());
         return;
     }
 
     QDir accountPersistentStorageDir(accountPersistentStoragePath(account));
     if (!accountPersistentStorageDir.exists()) {
-        QNDEBUG(QStringLiteral("No persistent storage dir exists for this account"));
+        QNDEBUG(QStringLiteral("No persistent storage dir exists for this account ") << account.name());
         return;
     }
 
@@ -625,7 +625,7 @@ void AccountManager::readComplementaryAccountInfo(Account & account)
 
     accountInfo.close();
 
-    QNDEBUG(QStringLiteral("Account after reading in the complementary info: ") << account);
+    QNTRACE(QStringLiteral("Account after reading in the complementary info: ") << account);
 }
 
 QSharedPointer<Account> AccountManager::accountFromEnvVarHints()
@@ -806,7 +806,7 @@ QSharedPointer<Account> AccountManager::findAccount(const bool isLocal,
 
 void AccountManager::updateLastUsedAccount(const Account & account)
 {
-    QNDEBUG(QStringLiteral("AccountManager::updateLastUsedAccount: ") << account);
+    QNDEBUG(QStringLiteral("AccountManager::updateLastUsedAccount: ") << account.name());
 
     ApplicationSettings appSettings;
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -720,7 +720,7 @@ void MainWindow::setupInitialChildWidgetsWidths()
 
 void MainWindow::setWindowTitleForAccount(const Account & account)
 {
-    QNDEBUG(QStringLiteral("MainWindow::setWindowTitleForAccount: ") << account);
+    QNDEBUG(QStringLiteral("MainWindow::setWindowTitleForAccount: ") << account.name());
 
     bool nonStandardPersistencePath = false;
     Q_UNUSED(applicationPersistentStoragePath(&nonStandardPersistencePath))
@@ -1826,7 +1826,7 @@ void MainWindow::onSynchronizationManagerFailure(ErrorString errorDescription)
 
 void MainWindow::onSynchronizationFinished(Account account, bool somethingDownloaded, bool somethingSent)
 {
-    QNINFO(QStringLiteral("MainWindow::onSynchronizationFinished: ") << account);
+    QNINFO(QStringLiteral("MainWindow::onSynchronizationFinished: ") << account.name());
 
     if (somethingDownloaded || somethingSent) {
         onSetStatusBarText(tr("Synchronization finished!"), SEC_TO_MSEC(5));
@@ -1852,7 +1852,7 @@ void MainWindow::onAuthenticationFinished(bool success, ErrorString errorDescrip
     QNINFO(QStringLiteral("MainWindow::onAuthenticationFinished: success = ")
             << (success ? QStringLiteral("true") : QStringLiteral("false"))
             << QStringLiteral(", error description = ") << errorDescription
-            << QStringLiteral(", account = ") << account);
+            << QStringLiteral(", account = ") << account.name());
 
     bool wasPendingNewEvernoteAccountAuthentication = m_pendingNewEvernoteAccountAuthentication;
     m_pendingNewEvernoteAccountAuthentication = false;
@@ -2893,7 +2893,7 @@ void MainWindow::onQuitRequestedFromSystemTrayIcon()
 
 void MainWindow::onAccountSwitchRequestedFromSystemTrayIcon(Account account)
 {
-    QNDEBUG(QStringLiteral("MainWindow::onAccountSwitchRequestedFromSystemTrayIcon: ") << account);
+    QNDEBUG(QStringLiteral("MainWindow::onAccountSwitchRequestedFromSystemTrayIcon: ") << account.name());
 
     stopListeningForSplitterMoves();
     m_pAccountManager->switchAccount(account);
@@ -3047,7 +3047,7 @@ void MainWindow::onSwitchAccountActionToggled(bool checked)
 
 void MainWindow::onAccountSwitched(Account account)
 {
-    QNDEBUG(QStringLiteral("MainWindow::onAccountSwitched: ") << account);
+    QNDEBUG(QStringLiteral("MainWindow::onAccountSwitched: ") << account.name());
 
     if (Q_UNLIKELY(!m_pLocalStorageManagerThread)) {
         ErrorString errorDescription(QT_TR_NOOP("internal error: no local storage manager thread exists"));
@@ -3101,7 +3101,7 @@ void MainWindow::onAccountSwitched(Account account)
 
 void MainWindow::onAccountUpdated(Account account)
 {
-    QNDEBUG(QStringLiteral("MainWindow::onAccountUpdated: ") << account);
+    QNDEBUG(QStringLiteral("MainWindow::onAccountUpdated: ") << account.name());
 
     if (!m_pAccount) {
         QNDEBUG(QStringLiteral("No account is current at the moment"));
@@ -3136,7 +3136,7 @@ void MainWindow::onAccountUpdated(Account account)
 
 void MainWindow::onAccountAdded(Account account)
 {
-    QNDEBUG(QStringLiteral("MainWindow::onAccountAdded: ") << account);
+    QNDEBUG(QStringLiteral("MainWindow::onAccountAdded: ") << account.name());
     updateSubMenuWithAvailableAccounts();
 }
 
@@ -3451,7 +3451,8 @@ void MainWindow::onSwitchPanelStyleToDarker()
 void MainWindow::onLocalStorageSwitchUserRequestComplete(Account account, QUuid requestId)
 {
     QNDEBUG(QStringLiteral("MainWindow::onLocalStorageSwitchUserRequestComplete: account = ")
-            << account << QStringLiteral(", request id = ") << requestId);
+            << account.name() << QStringLiteral(", request id = ") << requestId);
+    QNTRACE(account);
 
     bool expected = (m_lastLocalStorageSwitchUserRequest == requestId);
     m_lastLocalStorageSwitchUserRequest = QUuid();
@@ -3571,8 +3572,9 @@ void MainWindow::onLocalStorageSwitchUserRequestFailed(Account account, ErrorStr
         return;
     }
 
-    QNDEBUG(QStringLiteral("MainWindow::onLocalStorageSwitchUserRequestFailed: ") << account << QStringLiteral("\nError description: ")
+    QNDEBUG(QStringLiteral("MainWindow::onLocalStorageSwitchUserRequestFailed: ") << account.name() << QStringLiteral("\nError description: ")
             << errorDescription << QStringLiteral(", request id = ") << requestId);
+    QNTRACE(account);
 
     m_lastLocalStorageSwitchUserRequest = QUuid();
 
@@ -3696,7 +3698,7 @@ void MainWindow::onSyncIconAnimationFinished()
 
 void MainWindow::onSynchronizationManagerSetAccountDone(Account account)
 {
-    QNDEBUG(QStringLiteral("MainWindow::onSynchronizationManagerSetAccountDone: ") << account);
+    QNDEBUG(QStringLiteral("MainWindow::onSynchronizationManagerSetAccountDone: ") << account.name());
 
     QObject::disconnect(m_pSynchronizationManager, QNSIGNAL(SynchronizationManager,setAccountDone,Account),
                         this, QNSLOT(MainWindow,onSynchronizationManagerSetAccountDone,Account));
@@ -3756,7 +3758,7 @@ void MainWindow::onShortcutChanged(int key, QKeySequence shortcut, const Account
 {
     QNDEBUG(QStringLiteral("MainWindow::onShortcutChanged: key = ") << key << QStringLiteral(", shortcut: ")
             << shortcut.toString(QKeySequence::PortableText) << QStringLiteral(", context: ")
-            << context << QStringLiteral(", account: ") << account);
+            << context << QStringLiteral(", account: ") << account.name());
 
     auto it = m_shortcutKeyToAction.find(key);
     if (it == m_shortcutKeyToAction.end()) {
@@ -3775,7 +3777,7 @@ void MainWindow::onNonStandardShortcutChanged(QString nonStandardKey, QKeySequen
 {
     QNDEBUG(QStringLiteral("MainWindow::onNonStandardShortcutChanged: non-standard key = ")
             << nonStandardKey << QStringLiteral(", shortcut: ") << shortcut.toString(QKeySequence::PortableText)
-            << QStringLiteral(", context: ") << context << QStringLiteral(", account: ") << account);
+            << QStringLiteral(", context: ") << context << QStringLiteral(", account: ") << account.name());
 
     auto it = m_nonStandardShortcutKeyToAction.find(nonStandardKey);
     if (it == m_nonStandardShortcutKeyToAction.end()) {
@@ -4910,7 +4912,7 @@ void MainWindow::setSynchronizationOptions(const Account & account)
     QString inkNoteImagesStoragePath = accountPersistentStoragePath(account);
     inkNoteImagesStoragePath += QStringLiteral("/NoteEditorPage/inkNoteImages");
     QNTRACE(QStringLiteral("Ink note images storage path: ") << inkNoteImagesStoragePath
-            << QStringLiteral("; account: ") << account);
+            << QStringLiteral("; account: ") << account.name());
 
     m_pendingSynchronizationManagerSetInkNoteImagesStoragePath = true;
     Q_EMIT synchronizationSetInkNoteImagesStoragePath(inkNoteImagesStoragePath);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1809,7 +1809,7 @@ void MainWindow::onSynchronizationStarted()
 
 void MainWindow::onSynchronizationStopped()
 {
-    QNDEBUG(QStringLiteral("MainWindow::onSynchronizationStopped"));
+    QNWARNING(QStringLiteral("MainWindow::onSynchronizationStopped"));
 
     onSetStatusBarText(tr("Synchronization was stopped"), SEC_TO_MSEC(30));
     m_syncApiRateLimitExceeded = false;
@@ -1819,14 +1819,14 @@ void MainWindow::onSynchronizationStopped()
 
 void MainWindow::onSynchronizationManagerFailure(ErrorString errorDescription)
 {
-    QNDEBUG(QStringLiteral("MainWindow::onSynchronizationManagerFailure: ") << errorDescription);
+    QNERROR(QStringLiteral("MainWindow::onSynchronizationManagerFailure: ") << errorDescription);
     onSetStatusBarText(errorDescription.localizedString(), SEC_TO_MSEC(60));
     Q_EMIT stopSynchronization();
 }
 
 void MainWindow::onSynchronizationFinished(Account account, bool somethingDownloaded, bool somethingSent)
 {
-    QNDEBUG(QStringLiteral("MainWindow::onSynchronizationFinished: ") << account);
+    QNINFO(QStringLiteral("MainWindow::onSynchronizationFinished: ") << account);
 
     if (somethingDownloaded || somethingSent) {
         onSetStatusBarText(tr("Synchronization finished!"), SEC_TO_MSEC(5));
@@ -1849,7 +1849,7 @@ void MainWindow::onSynchronizationFinished(Account account, bool somethingDownlo
 
 void MainWindow::onAuthenticationFinished(bool success, ErrorString errorDescription, Account account)
 {
-    QNDEBUG(QStringLiteral("MainWindow::onAuthenticationFinished: success = ")
+    QNINFO(QStringLiteral("MainWindow::onAuthenticationFinished: success = ")
             << (success ? QStringLiteral("true") : QStringLiteral("false"))
             << QStringLiteral(", error description = ") << errorDescription
             << QStringLiteral(", account = ") << account);
@@ -1883,7 +1883,7 @@ void MainWindow::onAuthenticationFinished(bool success, ErrorString errorDescrip
 void MainWindow::onAuthenticationRevoked(bool success, ErrorString errorDescription,
                                          qevercloud::UserID userId)
 {
-    QNDEBUG(QStringLiteral("MainWindow::onAuthenticationRevoked: success = ")
+    QNINFO(QStringLiteral("MainWindow::onAuthenticationRevoked: success = ")
             << (success ? QStringLiteral("true") : QStringLiteral("false"))
             << QStringLiteral(", error description = ") << errorDescription
             << QStringLiteral(", user id = ") << userId);
@@ -1899,7 +1899,7 @@ void MainWindow::onAuthenticationRevoked(bool success, ErrorString errorDescript
 
 void MainWindow::onRateLimitExceeded(qint32 secondsToWait)
 {
-    QNDEBUG(QStringLiteral("MainWindow::onRateLimitExceeded: seconds to wait = ")
+    QNINFO(QStringLiteral("MainWindow::onRateLimitExceeded: seconds to wait = ")
             << secondsToWait);
 
     qint64 currentTimestamp = QDateTime::currentMSecsSinceEpoch();
@@ -1929,10 +1929,11 @@ void MainWindow::onRateLimitExceeded(qint32 secondsToWait)
 
 void MainWindow::onRemoteToLocalSyncDone(bool somethingDownloaded)
 {
-    QNDEBUG(QStringLiteral("MainWindow::onRemoteToLocalSyncDone"));
+    QNTRACE(QStringLiteral("MainWindow::onRemoteToLocalSyncDone"));
 
-    QNINFO(QStringLiteral("Remote to local sync done: something downloaded = ")
-            << (somethingDownloaded ? QStringLiteral("true") : QStringLiteral("false")));
+    QNINFO(QStringLiteral("Remote to local sync done: ")
+            << (somethingDownloaded ? QStringLiteral("received all updates from Evernote")
+                                    : QStringLiteral("no updates found on Evernote side")));
 
     if (somethingDownloaded) {
         onSetStatusBarText(tr("Received all updates from Evernote servers, sending local changes"));
@@ -1944,7 +1945,7 @@ void MainWindow::onRemoteToLocalSyncDone(bool somethingDownloaded)
 
 void MainWindow::onSyncChunksDownloadProgress(qint32 highestDownloadedUsn, qint32 highestServerUsn, qint32 lastPreviousUsn)
 {
-    QNDEBUG(QStringLiteral("MainWindow::onSyncChunksDownloadProgress: highest downloaded USN = ")
+    QNINFO(QStringLiteral("MainWindow::onSyncChunksDownloadProgress: highest downloaded USN = ")
             << highestDownloadedUsn << QStringLiteral(", highest server USN = ")
             << highestServerUsn << QStringLiteral(", last previous USN = ")
             << lastPreviousUsn);

--- a/src/NetworkProxySettingsHelpers.cpp
+++ b/src/NetworkProxySettingsHelpers.cpp
@@ -171,7 +171,7 @@ void parseNetworkProxySettings(const Account & currentAccount,
 
 void persistNetworkProxySettingsForAccount(const Account & account, const QNetworkProxy & proxy)
 {
-    QNDEBUG(QStringLiteral("persistNetworkProxySettingsForAccount: account = ") << account
+    QNDEBUG(QStringLiteral("persistNetworkProxySettingsForAccount: account = ") << account.name()
             << QStringLiteral("\nProxy type = ") << proxy.type() << QStringLiteral(", proxy host = ")
             << proxy.hostName() << QStringLiteral(", proxy port = ") << proxy.port()
             << QStringLiteral(", proxy user = ") << proxy.user());
@@ -199,7 +199,7 @@ void persistNetworkProxySettingsForAccount(const Account & account, const QNetwo
 
 void restoreNetworkProxySettingsForAccount(const Account & account)
 {
-    QNDEBUG(QStringLiteral("restoreNetworkProxySettingsForAccount: account = ") << account);
+    QNDEBUG(QStringLiteral("restoreNetworkProxySettingsForAccount: account = ") << account.name());
 
     QNetworkProxy::ProxyType type = QNetworkProxy::NoProxy;
     QString host;

--- a/src/NoteFiltersManager.cpp
+++ b/src/NoteFiltersManager.cpp
@@ -535,7 +535,7 @@ void NoteFiltersManager::onExpungeSavedSearchComplete(SavedSearch search, QUuid 
 
 void NoteFiltersManager::onAddNoteComplete(Note note, QUuid requestId)
 {
-    QNDEBUG(QStringLiteral("NoteFiltersManager::onAddNoteComplete: note = ") << note
+    QNTRACE(QStringLiteral("NoteFiltersManager::onAddNoteComplete: note = ") << note
             << QStringLiteral("\nRequest id = ") << requestId);
 
     m_noteFilterModel.invalidate();
@@ -543,7 +543,7 @@ void NoteFiltersManager::onAddNoteComplete(Note note, QUuid requestId)
 
 void NoteFiltersManager::onUpdateNoteComplete(Note note, bool updateResources, bool updateTags, QUuid requestId)
 {
-    QNDEBUG(QStringLiteral("NoteFiltersManager::onUpdateNoteComplete: note = ") << note
+    QNTRACE(QStringLiteral("NoteFiltersManager::onUpdateNoteComplete: note = ") << note
             << QStringLiteral("\nUpdate resources = ") << (updateResources ? QStringLiteral("true") : QStringLiteral("false"))
             << QStringLiteral(", update tags = ") << (updateTags ? QStringLiteral("true") : QStringLiteral("false"))
             << QStringLiteral(", request id = ") << requestId);
@@ -553,7 +553,7 @@ void NoteFiltersManager::onUpdateNoteComplete(Note note, bool updateResources, b
 
 void NoteFiltersManager::onExpungeNoteComplete(Note note, QUuid requestId)
 {
-    QNDEBUG(QStringLiteral("NoteFiltersManager::onExpungeNoteComplete: note = ") << note
+    QNTRACE(QStringLiteral("NoteFiltersManager::onExpungeNoteComplete: note = ") << note
             << QStringLiteral("\nRequest id = ") << requestId);
 
     m_noteFilterModel.invalidate();

--- a/src/models/FavoritesModel.cpp
+++ b/src/models/FavoritesModel.cpp
@@ -1904,7 +1904,7 @@ QVariant FavoritesModel::dataAccessibleText(const int row, const Columns::type c
 
 void FavoritesModel::removeItemByLocalUid(const QString & localUid)
 {
-    QNDEBUG(QStringLiteral("FavoritesModel::removeItemByLocalUid: local uid = ") << localUid);
+    QNTRACE(QStringLiteral("FavoritesModel::removeItemByLocalUid: local uid = ") << localUid);
 
     FavoritesDataByLocalUid & localUidIndex = m_data.get<ByLocalUid>();
     auto itemIt = localUidIndex.find(localUid);
@@ -2606,7 +2606,7 @@ void FavoritesModel::onNotebookAddedOrUpdated(const Notebook & notebook)
 
 void FavoritesModel::onTagAddedOrUpdated(const Tag & tag)
 {
-    QNDEBUG(QStringLiteral("FavoritesModel::onTagAddedOrUpdated: local uid = ") << tag.localUid());
+    QNTRACE(QStringLiteral("FavoritesModel::onTagAddedOrUpdated: local uid = ") << tag.localUid());
 
     m_tagCache.put(tag.localUid(), tag);
 

--- a/src/models/LogViewerModel.cpp
+++ b/src/models/LogViewerModel.cpp
@@ -67,7 +67,7 @@
         } \
         DateTimePrint::Options options(DateTimePrint::IncludeMilliseconds | DateTimePrint::IncludeTimezone); \
         QString fullMsg = printableDateTimeFromTimestamp(QDateTime::currentMSecsSinceEpoch(), options) + QStringLiteral(" ") + \
-                          relativeSourceFileName + QStringLiteral(" @ ") + QString::number(__LINE__) + \
+                          relativeSourceFileName + QStringLiteral(QNLOG_FILE_LINENUMBER_DELIMITER) + QString::number(__LINE__) + \
                           QStringLiteral(": ") + msg + QStringLiteral("\n"); \
         m_internalLogFile.write(fullMsg.toUtf8()); \
         m_internalLogFile.flush(); \
@@ -470,7 +470,7 @@ QString LogViewerModel::dataEntryToString(const LogViewerModel::Data & dataEntry
                                              )
          << QStringLiteral(" ")
          << dataEntry.m_sourceFileName
-         << QStringLiteral(" @ ")
+         << QStringLiteral(QNLOG_FILE_LINENUMBER_DELIMITER)
          << QString::number(dataEntry.m_sourceFileLineNumber)
          << QStringLiteral(" [")
          << LogViewerModel::logLevelToString(dataEntry.m_logLevel)

--- a/src/models/LogViewerModelLogFileParser.cpp
+++ b/src/models/LogViewerModelLogFileParser.cpp
@@ -54,7 +54,7 @@
         } \
         DateTimePrint::Options options(DateTimePrint::IncludeMilliseconds | DateTimePrint::IncludeTimezone); \
         QString fullMsg = printableDateTimeFromTimestamp(QDateTime::currentMSecsSinceEpoch(), options) + QStringLiteral(" ") + \
-                          relativeSourceFileName + QStringLiteral(" @ ") + QString::number(__LINE__) + \
+                          relativeSourceFileName + QStringLiteral(QNLOG_FILE_LINENUMBER_DELIMITER) + QString::number(__LINE__) + \
                           QStringLiteral(": ") + msg + QStringLiteral("\n"); \
         m_internalLogFile.write(fullMsg.toUtf8()); \
         m_internalLogFile.flush(); \
@@ -62,9 +62,21 @@
 
 namespace quentier {
 
+#define REGEX_QNLOG_DATE               "^(\\d{4}-\\d{2}-\\d{2}\\s+\\d{2}:\\d{2}:\\d{2}.\\d{3})\\s+(\\w+)"
+
+// note: QNLOG_FILE_LINENUMBER_DELIMITER is here incorporated into regex
+#define REGEX_QNLOG_SOURCE_LINENUMBER  "(.+):(\\d+)"
+
+// full logline regex
+#define REGEX_QNLOG_LINE               REGEX_QNLOG_DATE \
+                                       "\\s+" \
+                                       REGEX_QNLOG_SOURCE_LINENUMBER \
+                                       "\\s+" \
+                                       "\\[(\\w+)\\]:\\s(.+$)"
+
+
 LogViewerModel::LogFileParser::LogFileParser() :
-    m_logParsingRegex(QStringLiteral("^(\\d{4}-\\d{2}-\\d{2}\\s+\\d{2}:\\d{2}:\\d{2}.\\d{3})\\s+(\\w+)\\s+(.+)\\s+@\\s+(\\d+)\\s+\\[(\\w+)\\]:\\s(.+$)"),
-                      Qt::CaseInsensitive, QRegExp::RegExp),
+    m_logParsingRegex(QStringLiteral(REGEX_QNLOG_LINE), Qt::CaseInsensitive, QRegExp::RegExp),
     m_internalLogFile(applicationPersistentStoragePath() + QStringLiteral("/logs-quentier/LogViewerModelLogFileParserLog.txt")),
     m_internalLogEnabled(false)
 {

--- a/src/models/NoteModel.cpp
+++ b/src/models/NoteModel.cpp
@@ -224,7 +224,7 @@ QModelIndex NoteModel::createNoteItem(const QString & notebookLocalUid)
 
 bool NoteModel::deleteNote(const QString & noteLocalUid)
 {
-    NMDEBUG(QStringLiteral("NoteModel::deleteNote: ") << noteLocalUid);
+    NMINFO(QStringLiteral("NoteModel::deleteNote: ") << noteLocalUid);
 
     QModelIndex itemIndex = indexForLocalUid(noteLocalUid);
     if (!itemIndex.isValid()) {
@@ -710,7 +710,7 @@ bool NoteModel::removeRows(int row, int count, const QModelIndex & parent)
 
 void NoteModel::sort(int column, Qt::SortOrder order)
 {
-    NMDEBUG(QStringLiteral("NoteModel::sort: column = ") << column << QStringLiteral(", order = ") << order
+    NMTRACE(QStringLiteral("NoteModel::sort: column = ") << column << QStringLiteral(", order = ") << order
             << QStringLiteral(" (") << (order == Qt::AscendingOrder ? QStringLiteral("ascending") : QStringLiteral("descending"))
             << QStringLiteral(")"));
 
@@ -811,7 +811,7 @@ void NoteModel::sort(int column, Qt::SortOrder order)
 
 void NoteModel::onAddNoteComplete(Note note, QUuid requestId)
 {
-    NMDEBUG(QStringLiteral("NoteModel::onAddNoteComplete: ") << note << QStringLiteral("\nRequest id = ") << requestId);
+    NMTRACE(QStringLiteral("NoteModel::onAddNoteComplete: ") << note << QStringLiteral("\nRequest id = ") << requestId);
 
     ++m_numberOfNotesPerAccount;
 
@@ -831,7 +831,7 @@ void NoteModel::onAddNoteFailed(Note note, ErrorString errorDescription, QUuid r
         return;
     }
 
-    NMDEBUG(QStringLiteral("NoteModel::onAddNoteFailed: note = ") << note << QStringLiteral("\nError description = ")
+    NMTRACE(QStringLiteral("NoteModel::onAddNoteFailed: note = ") << note << QStringLiteral("\nError description = ")
             << errorDescription << QStringLiteral(", request id = ") << requestId);
 
     Q_UNUSED(m_addNoteRequestIds.erase(it))
@@ -842,7 +842,7 @@ void NoteModel::onAddNoteFailed(Note note, ErrorString errorDescription, QUuid r
 
 void NoteModel::onUpdateNoteComplete(Note note, bool updateResources, bool updateTags, QUuid requestId)
 {
-    NMDEBUG(QStringLiteral("NoteModel::onUpdateNoteComplete: note = ") << note << QStringLiteral("\nRequest id = ") << requestId);
+    NMTRACE(QStringLiteral("NoteModel::onUpdateNoteComplete: note = ") << note << QStringLiteral("\nRequest id = ") << requestId);
 
     Q_UNUSED(updateResources)
     Q_UNUSED(updateTags)
@@ -866,7 +866,7 @@ void NoteModel::onUpdateNoteComplete(Note note, bool updateResources, bool updat
             const NoteModelItem & item = *itemIt;
             note.setTagLocalUids(item.tagLocalUids());
             note.setTagGuids(item.tagGuids());
-            NMDEBUG(QStringLiteral("Complemented the note with tag local uids and guids: ") << note);
+            NMTRACE(QStringLiteral("Complemented the note with tag local uids and guids: ") << note);
         }
 
         m_cache.put(note.localUid(), note);
@@ -874,7 +874,7 @@ void NoteModel::onUpdateNoteComplete(Note note, bool updateResources, bool updat
         return;
     }
 
-    NMDEBUG(QStringLiteral("This update was not initiated by the note model: ") << note
+    NMTRACE(QStringLiteral("This update was not initiated by the note model: ") << note
             << QStringLiteral(", request id = ") << requestId << QStringLiteral(", update tags = ")
             << (updateTags ? QStringLiteral("true") : QStringLiteral("false"))
             << QStringLiteral(", should remove note from model = ")
@@ -890,7 +890,7 @@ void NoteModel::onUpdateNoteComplete(Note note, bool updateResources, bool updat
                 const NoteModelItem & item = *noteItemIt;
                 note.setTagGuids(item.tagGuids());
                 note.setTagLocalUids(item.tagLocalUids());
-                NMDEBUG(QStringLiteral("Complemented the note with tag local uids and guids: ") << note);
+                NMTRACE(QStringLiteral("Complemented the note with tag local uids and guids: ") << note);
             }
         }
 
@@ -909,7 +909,7 @@ void NoteModel::onUpdateNoteFailed(Note note, bool updateResources, bool updateT
         return;
     }
 
-    NMDEBUG(QStringLiteral("NoteModel::onUpdateNoteFailed: note = ") << note << QStringLiteral("\nError description = ")
+    NMTRACE(QStringLiteral("NoteModel::onUpdateNoteFailed: note = ") << note << QStringLiteral("\nError description = ")
             << errorDescription << QStringLiteral(", request id = ") << requestId);
 
     Q_UNUSED(m_updateNoteRequestIds.erase(it))
@@ -934,7 +934,7 @@ void NoteModel::onFindNoteComplete(Note note, bool withResourceBinaryData, QUuid
         return;
     }
 
-    NMDEBUG(QStringLiteral("NoteModel::onFindNoteComplete: note = ") << note << QStringLiteral("\nRequest id = ") << requestId);
+    NMTRACE(QStringLiteral("NoteModel::onFindNoteComplete: note = ") << note << QStringLiteral("\nRequest id = ") << requestId);
 
     if (restoreUpdateIt != m_findNoteToRestoreFailedUpdateRequestIds.end())
     {
@@ -966,7 +966,7 @@ void NoteModel::onFindNoteFailed(Note note, bool withResourceBinaryData, ErrorSt
         return;
     }
 
-    NMDEBUG(QStringLiteral("NoteModel::onFindNoteFailed: note = ") << note << QStringLiteral("\nError description = ")
+    NMTRACE(QStringLiteral("NoteModel::onFindNoteFailed: note = ") << note << QStringLiteral("\nError description = ")
             << errorDescription << QStringLiteral(", request id = ") << requestId);
 
     if (restoreUpdateIt != m_findNoteToRestoreFailedUpdateRequestIds.end()) {
@@ -988,7 +988,7 @@ void NoteModel::onListNotesComplete(LocalStorageManager::ListObjectsOptions flag
         return;
     }
 
-    NMDEBUG(QStringLiteral("NoteModel::onListNotesComplete: flag = ") << flag << QStringLiteral(", with resource binary data = ")
+    NMTRACE(QStringLiteral("NoteModel::onListNotesComplete: flag = ") << flag << QStringLiteral(", with resource binary data = ")
             << (withResourceBinaryData ? QStringLiteral("true") : QStringLiteral("false")) << QStringLiteral(", limit = ") << limit
             << QStringLiteral(", offset = ") << offset << QStringLiteral(", order = ") << order << QStringLiteral(", direction = ")
             << orderDirection << QStringLiteral(", linked notebook guid = ") << linkedNotebookGuid << QStringLiteral(", num found notes = ")
@@ -1020,7 +1020,7 @@ void NoteModel::onListNotesFailed(LocalStorageManager::ListObjectsOptions flag, 
         return;
     }
 
-    NMDEBUG(QStringLiteral("NoteModel::onListNotesFailed: flag = ") << flag << QStringLiteral(", with resource binary data = ")
+    NMTRACE(QStringLiteral("NoteModel::onListNotesFailed: flag = ") << flag << QStringLiteral(", with resource binary data = ")
             << (withResourceBinaryData ? QStringLiteral("true") : QStringLiteral("false")) << QStringLiteral(", limit = ")
             << limit << QStringLiteral(", offset = ") << offset << QStringLiteral(", order = ") << order << QStringLiteral(", direction = ")
             << orderDirection << QStringLiteral(", linked notebook guid = ") << linkedNotebookGuid
@@ -1032,7 +1032,7 @@ void NoteModel::onListNotesFailed(LocalStorageManager::ListObjectsOptions flag, 
 
 void NoteModel::onExpungeNoteComplete(Note note, QUuid requestId)
 {
-    NMDEBUG(QStringLiteral("NoteModel::onExpungeNoteComplete: note = ") << note << QStringLiteral("\nRequest id = ") << requestId);
+    NMTRACE(QStringLiteral("NoteModel::onExpungeNoteComplete: note = ") << note << QStringLiteral("\nRequest id = ") << requestId);
 
     --m_numberOfNotesPerAccount;
 
@@ -1052,7 +1052,7 @@ void NoteModel::onExpungeNoteFailed(Note note, ErrorString errorDescription, QUu
         return;
     }
 
-    NMDEBUG(QStringLiteral("NoteModel::onExpungeNoteFailed: note = ") << note << QStringLiteral("\nError description = ")
+    NMTRACE(QStringLiteral("NoteModel::onExpungeNoteFailed: note = ") << note << QStringLiteral("\nError description = ")
             << errorDescription << QStringLiteral(", request id = ") << requestId);
 
     Q_UNUSED(m_expungeNoteRequestIds.erase(it))
@@ -1073,7 +1073,7 @@ void NoteModel::onFindNotebookComplete(Notebook notebook, QUuid requestId)
         return;
     }
 
-    NMDEBUG(QStringLiteral("NoteModel::onFindNotebookComplete: notebook: ") << notebook << QStringLiteral("\nRequest id = ")
+    NMTRACE(QStringLiteral("NoteModel::onFindNotebookComplete: notebook: ") << notebook << QStringLiteral("\nRequest id = ")
             << requestId);
 
     m_notebookCache.put(notebook.localUid(), notebook);
@@ -1145,7 +1145,7 @@ void NoteModel::onAddNotebookComplete(Notebook notebook, QUuid requestId)
 
 void NoteModel::onUpdateNotebookComplete(Notebook notebook, QUuid requestId)
 {
-    NMDEBUG(QStringLiteral("NoteModel::onUpdateNotebookComplete: local uid = ") << notebook.localUid());
+    NMTRACE(QStringLiteral("NoteModel::onUpdateNotebookComplete: local uid = ") << notebook.localUid());
     Q_UNUSED(requestId)
     m_notebookCache.put(notebook.localUid(), notebook);
     updateNotebookData(notebook);
@@ -1153,7 +1153,7 @@ void NoteModel::onUpdateNotebookComplete(Notebook notebook, QUuid requestId)
 
 void NoteModel::onExpungeNotebookComplete(Notebook notebook, QUuid requestId)
 {
-    NMDEBUG(QStringLiteral("NoteModel::onExpungeNotebookComplete: local uid = ") << notebook.localUid());
+    NMTRACE(QStringLiteral("NoteModel::onExpungeNotebookComplete: local uid = ") << notebook.localUid());
 
     Q_UNUSED(requestId)
     Q_UNUSED(m_notebookCache.remove(notebook.localUid()))
@@ -1171,7 +1171,7 @@ void NoteModel::onFindTagComplete(Tag tag, QUuid requestId)
         return;
     }
 
-    NMDEBUG(QStringLiteral("NoteModel::onFindTagComplete: tag: ") << tag << QStringLiteral("\nRequest id = ") << requestId);
+    NMTRACE(QStringLiteral("NoteModel::onFindTagComplete: tag: ") << tag << QStringLiteral("\nRequest id = ") << requestId);
 
     Q_UNUSED(m_findTagRequestForTagLocalUid.right.erase(it))
     updateTagData(tag);
@@ -1196,19 +1196,19 @@ void NoteModel::onFindTagFailed(Tag tag, ErrorString errorDescription, QUuid req
 
 void NoteModel::onAddTagComplete(Tag tag, QUuid requestId)
 {
-    NMDEBUG(QStringLiteral("NoteModel::onAddTagComplete: tag = ") << tag << QStringLiteral(", request id = ") << requestId);
+    NMTRACE(QStringLiteral("NoteModel::onAddTagComplete: tag = ") << tag << QStringLiteral(", request id = ") << requestId);
     updateTagData(tag);
 }
 
 void NoteModel::onUpdateTagComplete(Tag tag, QUuid requestId)
 {
-    NMDEBUG(QStringLiteral("NoteModel::onUpdateTagComplete: tag = ") << tag << QStringLiteral(", request id = ") << requestId);
+    NMTRACE(QStringLiteral("NoteModel::onUpdateTagComplete: tag = ") << tag << QStringLiteral(", request id = ") << requestId);
     updateTagData(tag);
 }
 
 void NoteModel::onExpungeTagComplete(Tag tag, QStringList expungedChildTagLocalUids, QUuid requestId)
 {
-    NMDEBUG(QStringLiteral("NoteModel::onExpungeTagComplete: tag = ") << tag
+    NMTRACE(QStringLiteral("NoteModel::onExpungeTagComplete: tag = ") << tag
             << QStringLiteral("\nExpunged child tag local uids = ") << expungedChildTagLocalUids.join(QStringLiteral(", "))
             << QStringLiteral(", request id = ") << requestId);
 
@@ -1222,7 +1222,7 @@ void NoteModel::onExpungeTagComplete(Tag tag, QStringList expungedChildTagLocalU
 
 void NoteModel::createConnections(LocalStorageManagerAsync & localStorageManagerAsync)
 {
-    NMDEBUG(QStringLiteral("NoteModel::createConnections"));
+    NMTRACE(QStringLiteral("NoteModel::createConnections"));
 
     // Local signals to localStorageManagerAsync's slots
     QObject::connect(this, QNSIGNAL(NoteModel,addNote,Note,QUuid),
@@ -1294,7 +1294,7 @@ void NoteModel::createConnections(LocalStorageManagerAsync & localStorageManager
 
 void NoteModel::requestNotesList()
 {
-    NMDEBUG(QStringLiteral("NoteModel::requestNotesList: offset = ") << m_listNotesOffset);
+    NMTRACE(QStringLiteral("NoteModel::requestNotesList: offset = ") << m_listNotesOffset);
 
     LocalStorageManager::ListObjectsOptions flags = LocalStorageManager::ListAll;
     LocalStorageManager::ListNotesOrder::type order = LocalStorageManager::ListNotesOrder::NoOrder;
@@ -1504,7 +1504,7 @@ QVariant NoteModel::dataAccessibleText(const int row, const Columns::type column
 
 void NoteModel::processTagExpunging(const QString & tagLocalUid)
 {
-    NMDEBUG(QStringLiteral("NoteModel::processTagExpunging: tag local uid = ") << tagLocalUid);
+    NMTRACE(QStringLiteral("NoteModel::processTagExpunging: tag local uid = ") << tagLocalUid);
 
     auto tagDataIt = m_tagDataByTagLocalUid.find(tagLocalUid);
     if (tagDataIt == m_tagDataByTagLocalUid.end()) {
@@ -1537,7 +1537,7 @@ void NoteModel::processTagExpunging(const QString & tagLocalUid)
 
     Q_UNUSED(m_tagLocalUidToNoteLocalUid.remove(tagLocalUid))
 
-    NMDEBUG("Affected notes local uids: " << affectedNotesLocalUids.join(QStringLiteral(", ")));
+    NMTRACE("Affected notes local uids: " << affectedNotesLocalUids.join(QStringLiteral(", ")));
     for(auto it = affectedNotesLocalUids.constBegin(), end = affectedNotesLocalUids.constEnd(); it != end; ++it)
     {
         auto noteItemIt = localUidIndex.find(*it);
@@ -1653,7 +1653,7 @@ void NoteModel::updateItemRowWithRespectToSorting(const NoteModelItem & item)
 
 void NoteModel::updateNoteInLocalStorage(const NoteModelItem & item, const bool updateTags)
 {
-    NMDEBUG(QStringLiteral("NoteModel::updateNoteInLocalStorage: local uid = ")
+    NMTRACE(QStringLiteral("NoteModel::updateNoteInLocalStorage: local uid = ")
             << item.localUid() << QStringLiteral(", update tags = ")
             << (updateTags ? QStringLiteral("true") : QStringLiteral("false")));
 
@@ -1662,7 +1662,7 @@ void NoteModel::updateNoteInLocalStorage(const NoteModelItem & item, const bool 
     auto notYetSavedItemIt = m_noteItemsNotYetInLocalStorageUids.find(item.localUid());
     if (notYetSavedItemIt == m_noteItemsNotYetInLocalStorageUids.end())
     {
-        NMDEBUG(QStringLiteral("Updating the note"));
+        NMTRACE(QStringLiteral("Updating the note"));
 
         const Note * pCachedNote = m_cache.get(item.localUid());
         if (Q_UNLIKELY(!pCachedNote))
@@ -1762,7 +1762,7 @@ bool NoteModel::canCreateNoteItem(const QString & notebookLocalUid) const
 
 void NoteModel::updateNotebookData(const Notebook & notebook)
 {
-    NMDEBUG(QStringLiteral("NoteModel::updateNotebookData: local uid = ") << notebook.localUid());
+    NMTRACE(QStringLiteral("NoteModel::updateNotebookData: local uid = ") << notebook.localUid());
 
     NotebookData & notebookData = m_notebookDataByNotebookLocalUid[notebook.localUid()];
 
@@ -1790,7 +1790,7 @@ void NoteModel::updateNotebookData(const Notebook & notebook)
         notebookData.m_guid = notebook.guid();
     }
 
-    NMDEBUG(QStringLiteral("Collected notebook data from notebook with local uid ") << notebook.localUid()
+    NMTRACE(QStringLiteral("Collected notebook data from notebook with local uid ") << notebook.localUid()
             << QStringLiteral(": guid = ") << notebookData.m_guid << QStringLiteral("; name = ") << notebookData.m_name
             << QStringLiteral(": can create notes = ") << (notebookData.m_canCreateNotes ? QStringLiteral("true") : QStringLiteral("false"))
             << QStringLiteral(": can update notes = ") << (notebookData.m_canUpdateNotes ? QStringLiteral("true") : QStringLiteral("false")));
@@ -1800,7 +1800,7 @@ void NoteModel::updateNotebookData(const Notebook & notebook)
 
 void NoteModel::updateTagData(const Tag & tag)
 {
-    NMDEBUG(QStringLiteral("NoteModel::updateTagData: tag local uid = ") << tag.localUid());
+    NMTRACE(QStringLiteral("NoteModel::updateTagData: tag local uid = ") << tag.localUid());
 
     bool hasName = tag.hasName();
     bool hasGuid = tag.hasGuid();
@@ -1839,7 +1839,7 @@ void NoteModel::updateTagData(const Tag & tag)
         ++noteIt;
     }
 
-    NMDEBUG("Affected notes local uids: " << affectedNotesLocalUids.join(QStringLiteral(", ")));
+    NMTRACE("Affected notes local uids: " << affectedNotesLocalUids.join(QStringLiteral(", ")));
     for(auto it = affectedNotesLocalUids.constBegin(), end = affectedNotesLocalUids.constEnd(); it != end; ++it)
     {
         auto noteItemIt = localUidIndex.find(*it);
@@ -1923,8 +1923,7 @@ void NoteModel::checkAddedNoteItemsPendingNotebookData(const QString & notebookL
 
 void NoteModel::onNoteAddedOrUpdated(const Note & note)
 {
-    NMDEBUG(QStringLiteral("NoteModel::onNoteAddedOrUpdated: note local uid = ") << note.localUid());
-    NMTRACE(note);
+    NMTRACE(QStringLiteral("NoteModel::onNoteAddedOrUpdated: note local uid = ") << note);
 
     m_cache.put(note.localUid(), note);
 
@@ -1979,7 +1978,7 @@ void NoteModel::onNoteAddedOrUpdated(const Note & note)
 
 void NoteModel::addOrUpdateNoteItem(NoteModelItem & item, const NotebookData & notebookData)
 {
-    NMDEBUG(QStringLiteral("NoteModel::addOrUpdateNoteItem: note local uid = ") << item.localUid()
+    NMTRACE(QStringLiteral("NoteModel::addOrUpdateNoteItem: note local uid = ") << item.localUid()
             << QStringLiteral(", notebook local uid = ") << item.notebookLocalUid()
             << QStringLiteral(", notebook name = ") << notebookData.m_name);
 
@@ -1997,7 +1996,7 @@ void NoteModel::addOrUpdateNoteItem(NoteModelItem & item, const NotebookData & n
         case IncludedNotes::Deleted:
             {
                 if (item.deletionTimestamp() < 0) {
-                    NMDEBUG(QStringLiteral("Won't add note as it's not deleted and the model instance only considers the deleted notes"));
+                    NMTRACE(QStringLiteral("Won't add note as it's not deleted and the model instance only considers the deleted notes"));
                     return;
                 }
                 break;
@@ -2142,7 +2141,7 @@ void NoteModel::moveNoteToNotebookImpl(NoteDataByLocalUid::iterator it, const No
 {
     NoteModelItem item = *it;
 
-    NMDEBUG(QStringLiteral("NoteModel::moveNoteToNotebookImpl: notebook = ") << notebook
+    NMTRACE(QStringLiteral("NoteModel::moveNoteToNotebookImpl: notebook = ") << notebook
             << QStringLiteral(", note item: ") << item);
 
     if (Q_UNLIKELY(item.notebookLocalUid() == notebook.localUid())) {
@@ -2178,7 +2177,7 @@ void NoteModel::moveNoteToNotebookImpl(NoteDataByLocalUid::iterator it, const No
 
 void NoteModel::checkAndNotifyAllNotesListed()
 {
-    NMDEBUG(QStringLiteral("NoteModel::checkAndNotifyAllNotesListed"));
+    NMTRACE(QStringLiteral("NoteModel::checkAndNotifyAllNotesListed"));
 
     if (m_allNotesListed) {
         NMDEBUG(QStringLiteral("All notes are already listed"));

--- a/src/models/NoteModel.cpp
+++ b/src/models/NoteModel.cpp
@@ -2079,7 +2079,7 @@ void NoteModel::addOrUpdateNoteItem(NoteModelItem & item, const NotebookData & n
 
 void NoteModel::findTagNamesForItem(NoteModelItem & item)
 {
-    NMDEBUG(QStringLiteral("NoteModel::findTagNamesForItem: ") << item);
+    NMTRACE(QStringLiteral("NoteModel::findTagNamesForItem: ") << item);
 
     const QStringList & tagLocalUids = item.tagLocalUids();
     for(auto it = tagLocalUids.constBegin(), end = tagLocalUids.constEnd(); it != end; ++it)

--- a/src/models/NotebookModel.cpp
+++ b/src/models/NotebookModel.cpp
@@ -92,7 +92,7 @@ NotebookModel::~NotebookModel()
 
 void NotebookModel::updateAccount(const Account & account)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::updateAccount: ") << account);
+    QNTRACE(QStringLiteral("NotebookModel::updateAccount: ") << account);
     m_account = account;
 }
 
@@ -201,7 +201,7 @@ QModelIndex NotebookModel::indexForNotebookStack(const QString & stack, const QS
 
 QModelIndex NotebookModel::indexForLinkedNotebookGuid(const QString & linkedNotebookGuid) const
 {
-    QNDEBUG(QStringLiteral("NotebookModel::indexForLinkedNotebookGuid: linked notebook guid = ")
+    QNTRACE(QStringLiteral("NotebookModel::indexForLinkedNotebookGuid: linked notebook guid = ")
             << linkedNotebookGuid);
 
     auto it = m_modelItemsByLinkedNotebookGuid.find(linkedNotebookGuid);
@@ -216,7 +216,7 @@ QModelIndex NotebookModel::indexForLinkedNotebookGuid(const QString & linkedNote
 
 QStringList NotebookModel::notebookNames(const NotebookFilters filters, const QString & linkedNotebookGuid) const
 {
-    QNDEBUG(QStringLiteral("NotebookModel::notebookNames: filters = ") << filters
+    QNTRACE(QStringLiteral("NotebookModel::notebookNames: filters = ") << filters
             << QStringLiteral(", linked notebook guid = ") << linkedNotebookGuid
             << QStringLiteral(" (null = ") << (linkedNotebookGuid.isNull() ? QStringLiteral("true") : QStringLiteral("false"))
             << QStringLiteral(", empty = ") << (linkedNotebookGuid.isEmpty() ? QStringLiteral("true") : QStringLiteral("false"))
@@ -320,7 +320,7 @@ QModelIndexList NotebookModel::persistentIndexes() const
 
 QModelIndex NotebookModel::defaultNotebookIndex() const
 {
-    QNDEBUG(QStringLiteral("NotebookModel::defaultNotebookIndex"));
+    QNTRACE(QStringLiteral("NotebookModel::defaultNotebookIndex"));
 
     if (m_defaultNotebookLocalUid.isEmpty()) {
         QNDEBUG(QStringLiteral("No default notebook local uid"));
@@ -332,7 +332,7 @@ QModelIndex NotebookModel::defaultNotebookIndex() const
 
 QModelIndex NotebookModel::lastUsedNotebookIndex() const
 {
-    QNDEBUG(QStringLiteral("NotebookModel::lastUsedNotebookIndex"));
+    QNTRACE(QStringLiteral("NotebookModel::lastUsedNotebookIndex"));
 
     if (m_lastUsedNotebookLocalUid.isEmpty()) {
         QNDEBUG(QStringLiteral("No last used notebook local uid"));
@@ -344,7 +344,7 @@ QModelIndex NotebookModel::lastUsedNotebookIndex() const
 
 QModelIndex NotebookModel::moveToStack(const QModelIndex & index, const QString & stack)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::moveToStack: stack = ") << stack);
+    QNTRACE(QStringLiteral("NotebookModel::moveToStack: stack = ") << stack);
 
     if (Q_UNLIKELY(stack.isEmpty())) {
         return removeFromStack(index);
@@ -477,7 +477,7 @@ QModelIndex NotebookModel::moveToStack(const QModelIndex & index, const QString 
 
 QModelIndex NotebookModel::removeFromStack(const QModelIndex & index)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::removeFromStack"));
+    QNTRACE(QStringLiteral("NotebookModel::removeFromStack"));
 
     const NotebookModelItem * pModelItem = itemForId(static_cast<IndexId>(index.internalId()));
     if (Q_UNLIKELY(!pModelItem)) {
@@ -566,7 +566,7 @@ QModelIndex NotebookModel::removeFromStack(const QModelIndex & index)
 
 QStringList NotebookModel::stacks(const QString & linkedNotebookGuid) const
 {
-    QNDEBUG(QStringLiteral("NotebookModel::stacks: linked notebook guid = ")
+    QNTRACE(QStringLiteral("NotebookModel::stacks: linked notebook guid = ")
             << linkedNotebookGuid);
 
     QStringList result;
@@ -606,7 +606,7 @@ QModelIndex NotebookModel::createNotebook(const QString & notebookName,
                                           const QString & notebookStack,
                                           ErrorString & errorDescription)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::createNotebook: notebook name = ")
+    QNTRACE(QStringLiteral("NotebookModel::createNotebook: notebook name = ")
             << notebookName << QStringLiteral(", notebook stack = ") << notebookStack);
 
     if (notebookName.isEmpty()) {
@@ -765,7 +765,7 @@ bool NotebookModel::allNotebooksListed() const
 
 void NotebookModel::favoriteNotebook(const QModelIndex & index)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::favoriteNotebook: index: is valid = ")
+    QNTRACE(QStringLiteral("NotebookModel::favoriteNotebook: index: is valid = ")
             << (index.isValid() ? QStringLiteral("true") : QStringLiteral("false"))
             << QStringLiteral(", row = ") << index.row() << QStringLiteral(", column = ")
             << index.column() << QStringLiteral(", internal id = ") << index.internalId());
@@ -775,7 +775,7 @@ void NotebookModel::favoriteNotebook(const QModelIndex & index)
 
 void NotebookModel::unfavoriteNotebook(const QModelIndex & index)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::unfavoriteNotebook: index: is valid = ")
+    QNTRACE(QStringLiteral("NotebookModel::unfavoriteNotebook: index: is valid = ")
             << (index.isValid() ? QStringLiteral("true") : QStringLiteral("false"))
             << QStringLiteral(", row = ") << index.row() << QStringLiteral(", column = ")
             << index.column() << QStringLiteral(", internal id = ") << index.internalId());
@@ -786,7 +786,7 @@ void NotebookModel::unfavoriteNotebook(const QModelIndex & index)
 QString NotebookModel::localUidForItemName(const QString & itemName,
                                            const QString & linkedNotebookGuid) const
 {
-    QNDEBUG(QStringLiteral("NotebookModel::localUidForItemName: name = ") << itemName
+    QNTRACE(QStringLiteral("NotebookModel::localUidForItemName: name = ") << itemName
             << QStringLiteral(", linked notebook guid = ") << linkedNotebookGuid);
 
     QModelIndex index = indexForNotebookName(itemName, linkedNotebookGuid);
@@ -813,7 +813,7 @@ QString NotebookModel::localUidForItemName(const QString & itemName,
 
 QString NotebookModel::itemNameForLocalUid(const QString & localUid) const
 {
-    QNDEBUG(QStringLiteral("NotebookModel::itemNameForLocalUid: ") << localUid);
+    QNTRACE(QStringLiteral("NotebookModel::itemNameForLocalUid: ") << localUid);
 
     const NotebookDataByLocalUid & localUidIndex = m_data.get<ByLocalUid>();
     auto it = localUidIndex.find(localUid);
@@ -1127,7 +1127,7 @@ bool NotebookModel::setHeaderData(int section, Qt::Orientation orientation, cons
 
 bool NotebookModel::setData(const QModelIndex & modelIndex, const QVariant & value, int role)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::setData: row = ") << modelIndex.row()
+    QNTRACE(QStringLiteral("NotebookModel::setData: row = ") << modelIndex.row()
             << QStringLiteral(", column = ") << modelIndex.column()
             << QStringLiteral(", internal id = ") << modelIndex.internalId()
             << QStringLiteral(", value = ") << value << QStringLiteral(", role = ") << role);
@@ -1620,7 +1620,7 @@ bool NotebookModel::setData(const QModelIndex & modelIndex, const QVariant & val
 
 bool NotebookModel::insertRows(int row, int count, const QModelIndex & parent)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::insertRows: row = ") << row << QStringLiteral(", count = ") << count
+    QNTRACE(QStringLiteral("NotebookModel::insertRows: row = ") << row << QStringLiteral(", count = ") << count
             << QStringLiteral(", parent: is valid = ") << (parent.isValid() ? QStringLiteral("true") : QStringLiteral("false"))
             << QStringLiteral(", row = ") << parent.row() << QStringLiteral(", column = ") << parent.column());
 
@@ -1706,7 +1706,7 @@ bool NotebookModel::insertRows(int row, int count, const QModelIndex & parent)
 
 bool NotebookModel::removeRows(int row, int count, const QModelIndex & parent)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::removeRows: row = ") << row
+    QNTRACE(QStringLiteral("NotebookModel::removeRows: row = ") << row
             << QStringLiteral(", count = ") << count << QStringLiteral(", parent index: row = ")
             << parent.row() << QStringLiteral(", column = ") << parent.column()
             << QStringLiteral(", internal id = ") << parent.internalId());
@@ -1977,13 +1977,13 @@ bool NotebookModel::removeRows(int row, int count, const QModelIndex & parent)
         }
     }
 
-    QNDEBUG(QStringLiteral("Successfully removed the row(s)"));
+    QNTRACE(QStringLiteral("Successfully removed the row(s)"));
     return true;
 }
 
 void NotebookModel::sort(int column, Qt::SortOrder order)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::sort: column = ") << column
+    QNTRACE(QStringLiteral("NotebookModel::sort: column = ") << column
             << QStringLiteral(", order = ") << order << QStringLiteral(" (")
             << (order == Qt::AscendingOrder ? QStringLiteral("ascending") : QStringLiteral("descending"))
             << QStringLiteral(")"));
@@ -2056,7 +2056,7 @@ QMimeData * NotebookModel::mimeData(const QModelIndexList & indexes) const
 bool NotebookModel::dropMimeData(const QMimeData * pMimeData, Qt::DropAction action,
                                  int row, int column, const QModelIndex & parentIndex)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::dropMimeData: action = ") << action << QStringLiteral(", row = ") << row
+    QNTRACE(QStringLiteral("NotebookModel::dropMimeData: action = ") << action << QStringLiteral(", row = ") << row
             << QStringLiteral(", column = ") << column << QStringLiteral(", parent index: is valid = ")
             << (parentIndex.isValid() ? QStringLiteral("true") : QStringLiteral("false"))
             << QStringLiteral(", parent row = ") << parentIndex.row() << QStringLiteral(", parent column = ")
@@ -2166,7 +2166,7 @@ bool NotebookModel::dropMimeData(const QMimeData * pMimeData, Qt::DropAction act
 
 void NotebookModel::onAllNotesListed()
 {
-    QNDEBUG(QStringLiteral("NotebookModel::onAllNotesListed"));
+    QNTRACE(QStringLiteral("NotebookModel::onAllNotesListed"));
 
     NoteModel * pNoteModel = qobject_cast<NoteModel*>(sender());
     if (Q_UNLIKELY(!pNoteModel)) {
@@ -2185,7 +2185,7 @@ void NotebookModel::onAllNotesListed()
 
 void NotebookModel::onAddNotebookComplete(Notebook notebook, QUuid requestId)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::onAddNotebookComplete: notebook = ") << notebook << QStringLiteral("\nRequest id = ")
+    QNTRACE(QStringLiteral("NotebookModel::onAddNotebookComplete: notebook = ") << notebook << QStringLiteral("\nRequest id = ")
             << requestId);
 
     auto it = m_addNotebookRequestIds.find(requestId);
@@ -2205,7 +2205,7 @@ void NotebookModel::onAddNotebookFailed(Notebook notebook, ErrorString errorDesc
         return;
     }
 
-    QNDEBUG(QStringLiteral("NotebookModel::onAddNotebookFailed: notebook = ") << notebook << QStringLiteral("\nError description = ")
+    QNWARNING(QStringLiteral("NotebookModel::onAddNotebookFailed: notebook = ") << notebook << QStringLiteral("\nError description = ")
             << errorDescription << QStringLiteral(", request id = ") << requestId);
 
     Q_UNUSED(m_addNotebookRequestIds.erase(it))
@@ -2217,7 +2217,7 @@ void NotebookModel::onAddNotebookFailed(Notebook notebook, ErrorString errorDesc
 
 void NotebookModel::onUpdateNotebookComplete(Notebook notebook, QUuid requestId)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::onUpdateNotebookComplete: notebook = ") << notebook << QStringLiteral("\nRequest id = ")
+    QNTRACE(QStringLiteral("NotebookModel::onUpdateNotebookComplete: notebook = ") << notebook << QStringLiteral("\nRequest id = ")
             << requestId);
 
     auto it = m_updateNotebookRequestIds.find(requestId);
@@ -2236,7 +2236,7 @@ void NotebookModel::onUpdateNotebookFailed(Notebook notebook, ErrorString errorD
         return;
     }
 
-    QNDEBUG(QStringLiteral("NotebookModel::onUpdateNotebookFailed: notebook = ") << notebook << QStringLiteral("\nError description = ")
+    QNWARNING(QStringLiteral("NotebookModel::onUpdateNotebookFailed: notebook = ") << notebook << QStringLiteral("\nError description = ")
             << errorDescription << QStringLiteral(", request id = ") << requestId);
 
     Q_UNUSED(m_updateNotebookRequestIds.erase(it))
@@ -2258,7 +2258,7 @@ void NotebookModel::onFindNotebookComplete(Notebook notebook, QUuid requestId)
         return;
     }
 
-    QNDEBUG(QStringLiteral("NotebookModel::onFindNotebookComplete: notebook = ") << notebook << QStringLiteral("\nRequest id = ") << requestId);
+    QNTRACE(QStringLiteral("NotebookModel::onFindNotebookComplete: notebook = ") << notebook << QStringLiteral("\nRequest id = ") << requestId);
 
     if (restoreUpdateIt != m_findNotebookToRestoreFailedUpdateRequestIds.end())
     {
@@ -2287,7 +2287,7 @@ void NotebookModel::onFindNotebookFailed(Notebook notebook, ErrorString errorDes
         return;
     }
 
-    QNDEBUG(QStringLiteral("NotebookModel::onFindNotebookFailed: notebook = ") << notebook << QStringLiteral("\nError description = ")
+    QNWARNING(QStringLiteral("NotebookModel::onFindNotebookFailed: notebook = ") << notebook << QStringLiteral("\nError description = ")
             << errorDescription << QStringLiteral(", request id = ") << requestId);
 
     if (restoreUpdateIt != m_findNotebookToRestoreFailedUpdateRequestIds.end()) {
@@ -2310,7 +2310,7 @@ void NotebookModel::onListNotebooksComplete(LocalStorageManager::ListObjectsOpti
         return;
     }
 
-    QNDEBUG(QStringLiteral("NotebookModel::onListNotebooksComplete: flag = ") << flag << QStringLiteral(", limit = ")
+    QNTRACE(QStringLiteral("NotebookModel::onListNotebooksComplete: flag = ") << flag << QStringLiteral(", limit = ")
             << limit << QStringLiteral(", offset = ") << offset << QStringLiteral(", order = ") << order
             << QStringLiteral(", direction = ") << orderDirection << QStringLiteral(", linked notebook guid = ")
             << (linkedNotebookGuid.isNull() ? QStringLiteral("<null>") : linkedNotebookGuid) << QStringLiteral(", num found notebooks = ")
@@ -2349,7 +2349,7 @@ void NotebookModel::onListNotebooksFailed(LocalStorageManager::ListObjectsOption
         return;
     }
 
-    QNDEBUG(QStringLiteral("NotebookModel::onListNotebooksFailed: flag = ") << flag << QStringLiteral(", limit = ")
+    QNWARNING(QStringLiteral("NotebookModel::onListNotebooksFailed: flag = ") << flag << QStringLiteral(", limit = ")
             << limit << QStringLiteral(", offset = ") << offset << QStringLiteral(", order = ") << order
             << QStringLiteral(", direction = ") << orderDirection << QStringLiteral(", linked notebook guid = ")
             << (linkedNotebookGuid.isNull() ? QStringLiteral("<null>") : linkedNotebookGuid) << QStringLiteral(", error description = ")
@@ -2362,7 +2362,7 @@ void NotebookModel::onListNotebooksFailed(LocalStorageManager::ListObjectsOption
 
 void NotebookModel::onExpungeNotebookComplete(Notebook notebook, QUuid requestId)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::onExpungeNotebookComplete: notebook = ") << notebook
+    QNTRACE(QStringLiteral("NotebookModel::onExpungeNotebookComplete: notebook = ") << notebook
             << QStringLiteral("\nRequest id = ") << requestId);
 
     auto it = m_expungeNotebookRequestIds.find(requestId);
@@ -2383,7 +2383,7 @@ void NotebookModel::onExpungeNotebookFailed(Notebook notebook, ErrorString error
         return;
     }
 
-    QNDEBUG(QStringLiteral("NotebookModel::onExpungeNotebookFailed: notebook = ") << notebook << QStringLiteral("\nError description = ")
+    QNWARNING(QStringLiteral("NotebookModel::onExpungeNotebookFailed: notebook = ") << notebook << QStringLiteral("\nError description = ")
             << errorDescription << QStringLiteral(", request id = ") << requestId);
 
     Q_UNUSED(m_expungeNotebookRequestIds.erase(it))
@@ -2399,7 +2399,7 @@ void NotebookModel::onGetNoteCountPerNotebookComplete(int noteCount, Notebook no
         return;
     }
 
-    QNDEBUG(QStringLiteral("NotebookModel::onGetNoteCountPerNotebookComplete: note count = ") << noteCount
+    QNTRACE(QStringLiteral("NotebookModel::onGetNoteCountPerNotebookComplete: note count = ") << noteCount
             << QStringLiteral(", notebook = ") << notebook << QStringLiteral("\nRequest id = ") << requestId);
 
     Q_UNUSED(m_noteCountPerNotebookRequestIds.erase(it))
@@ -2450,7 +2450,7 @@ void NotebookModel::onGetNoteCountPerNotebookFailed(ErrorString errorDescription
 
 void NotebookModel::onAddNoteComplete(Note note, QUuid requestId)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::onAddNoteComplete: note = ") << note
+    QNTRACE(QStringLiteral("NotebookModel::onAddNoteComplete: note = ") << note
             << QStringLiteral(", request id = ") << requestId);
 
     if (note.hasNotebookLocalUid())
@@ -2483,7 +2483,7 @@ void NotebookModel::onAddNoteComplete(Note note, QUuid requestId)
 
 void NotebookModel::onUpdateNoteComplete(Note note, bool updateResources, bool updateTags, QUuid requestId)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::onUpdateNoteComplete: note = ") << note
+    QNTRACE(QStringLiteral("NotebookModel::onUpdateNoteComplete: note = ") << note
             << QStringLiteral("\nUpdate resources = ") << (updateResources ? QStringLiteral("true") : QStringLiteral("false"))
             << QStringLiteral(", update tags = ") << (updateTags ? QStringLiteral("true") : QStringLiteral("false"))
             << QStringLiteral(", request id = ") << requestId);
@@ -2523,7 +2523,7 @@ void NotebookModel::onUpdateNoteComplete(Note note, bool updateResources, bool u
         return;
     }
 
-    QNDEBUG(QStringLiteral("The note's notebook local uid has changed: was ") << oldNotebookLocalUid
+    QNTRACE(QStringLiteral("The note's notebook local uid has changed: was ") << oldNotebookLocalUid
             << QStringLiteral(", now ") << newNotebookLocalUid);
 
     Notebook oldNotebook;
@@ -2537,7 +2537,7 @@ void NotebookModel::onUpdateNoteComplete(Note note, bool updateResources, bool u
 
 void NotebookModel::onExpungeNoteComplete(Note note, QUuid requestId)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::onExpungeNoteComplete: note = ") << note
+    QNTRACE(QStringLiteral("NotebookModel::onExpungeNoteComplete: note = ") << note
             << QStringLiteral("\nRequest id = ") << requestId);
 
     QString notebookLocalUid;
@@ -2580,21 +2580,21 @@ void NotebookModel::onExpungeNoteComplete(Note note, QUuid requestId)
 
 void NotebookModel::onAddLinkedNotebookComplete(LinkedNotebook linkedNotebook, QUuid requestId)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::onAddLinkedNotebookComplete: request id = ")
+    QNTRACE(QStringLiteral("NotebookModel::onAddLinkedNotebookComplete: request id = ")
             << requestId << QStringLiteral(", linked notebook: ") << linkedNotebook);
     onLinkedNotebookAddedOrUpdated(linkedNotebook);
 }
 
 void NotebookModel::onUpdateLinkedNotebookComplete(LinkedNotebook linkedNotebook, QUuid requestId)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::onUpdateLinkedNotebookComplete: request id = ")
+    QNTRACE(QStringLiteral("NotebookModel::onUpdateLinkedNotebookComplete: request id = ")
             << requestId << QStringLiteral(", linked notebook: ") << linkedNotebook);
     onLinkedNotebookAddedOrUpdated(linkedNotebook);
 }
 
 void NotebookModel::onExpungeLinkedNotebookComplete(LinkedNotebook linkedNotebook, QUuid requestId)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::onExpungeLinkedNotebookComplete: request id = ")
+    QNTRACE(QStringLiteral("NotebookModel::onExpungeLinkedNotebookComplete: request id = ")
             << requestId << QStringLiteral(", linked notebook: ") << linkedNotebook);
 
     if (Q_UNLIKELY(!linkedNotebook.hasGuid())) {
@@ -2663,7 +2663,7 @@ void NotebookModel::onListAllLinkedNotebooksComplete(size_t limit, size_t offset
         return;
     }
 
-    QNDEBUG(QStringLiteral("NotebookModel::onListAllLinkedNotebooksComplete: limit = ")
+    QNTRACE(QStringLiteral("NotebookModel::onListAllLinkedNotebooksComplete: limit = ")
             << limit << QStringLiteral(", offset = ") << offset << QStringLiteral(", order = ")
             << order << QStringLiteral(", order direction = ") << orderDirection
             << QStringLiteral(", request id = ") << requestId);
@@ -2699,7 +2699,7 @@ void NotebookModel::onListAllLinkedNotebooksFailed(size_t limit, size_t offset,
         return;
     }
 
-    QNDEBUG(QStringLiteral("NotebookModel::onListAllLinkedNotebooksFailed: limit = ") << limit
+    QNWARNING(QStringLiteral("NotebookModel::onListAllLinkedNotebooksFailed: limit = ") << limit
             << QStringLiteral(", offset = ") << offset << QStringLiteral(", order = ") << order
             << QStringLiteral(", order direction = ") << orderDirection << QStringLiteral(", error description = ")
             << errorDescription << QStringLiteral(", request id = ") << requestId);
@@ -2711,7 +2711,7 @@ void NotebookModel::onListAllLinkedNotebooksFailed(size_t limit, size_t offset,
 
 void NotebookModel::createConnections(const NoteModel & noteModel, LocalStorageManagerAsync & localStorageManagerAsync)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::createConnections"));
+    QNTRACE(QStringLiteral("NotebookModel::createConnections"));
 
     if (!noteModel.allNotesListed()) {
         QObject::connect(&noteModel, QNSIGNAL(NoteModel,notifyAllNotesListed),
@@ -2809,7 +2809,7 @@ void NotebookModel::createConnections(const NoteModel & noteModel, LocalStorageM
 
 void NotebookModel::requestNotebooksList()
 {
-    QNDEBUG(QStringLiteral("NotebookModel::requestNotebooksList: offset = ") << m_listNotebooksOffset);
+    QNTRACE(QStringLiteral("NotebookModel::requestNotebooksList: offset = ") << m_listNotebooksOffset);
 
     LocalStorageManager::ListObjectsOptions flags = LocalStorageManager::ListAll;
     LocalStorageManager::ListNotebooksOrder::type order = LocalStorageManager::ListNotebooksOrder::NoOrder;
@@ -2823,7 +2823,7 @@ void NotebookModel::requestNotebooksList()
 
 void NotebookModel::requestNoteCountForNotebook(const Notebook & notebook)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::requestNoteCountForNotebook: ") << notebook);
+    QNTRACE(QStringLiteral("NotebookModel::requestNoteCountForNotebook: ") << notebook);
 
     QUuid requestId = QUuid::createUuid();
     Q_UNUSED(m_noteCountPerNotebookRequestIds.insert(requestId))
@@ -2833,7 +2833,7 @@ void NotebookModel::requestNoteCountForNotebook(const Notebook & notebook)
 
 void NotebookModel::requestNoteCountForAllNotebooks()
 {
-    QNDEBUG(QStringLiteral("NotebookModel::requestNoteCountForAllNotebooks"));
+    QNTRACE(QStringLiteral("NotebookModel::requestNoteCountForAllNotebooks"));
 
     const NotebookDataByLocalUid & localUidIndex = m_data.get<ByLocalUid>();
 
@@ -2847,7 +2847,7 @@ void NotebookModel::requestNoteCountForAllNotebooks()
 
 void NotebookModel::requestLinkedNotebooksList()
 {
-    QNDEBUG(QStringLiteral("NotebookModel::requestLinkedNotebooksList: offset = ") << m_listLinkedNotebooksOffset);
+    QNTRACE(QStringLiteral("NotebookModel::requestLinkedNotebooksList: offset = ") << m_listLinkedNotebooksOffset);
 
     LocalStorageManager::ListLinkedNotebooksOrder::type order = LocalStorageManager::ListLinkedNotebooksOrder::NoOrder;
     LocalStorageManager::OrderDirection::type direction = LocalStorageManager::OrderDirection::Ascending;
@@ -3066,7 +3066,7 @@ bool NotebookModel::canUpdateNotebookItem(const NotebookItem & item) const
 
 void NotebookModel::updateNotebookInLocalStorage(const NotebookItem & item)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::updateNotebookInLocalStorage: local uid = ") << item.localUid());
+    QNTRACE(QStringLiteral("NotebookModel::updateNotebookInLocalStorage: local uid = ") << item.localUid());
 
     Notebook notebook;
 
@@ -3146,7 +3146,7 @@ void NotebookModel::updateNotebookInLocalStorage(const NotebookItem & item)
 
 void NotebookModel::expungeNotebookFromLocalStorage(const QString & localUid)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::expungeNotebookFromLocalStorage: local uid = ")
+    QNTRACE(QStringLiteral("NotebookModel::expungeNotebookFromLocalStorage: local uid = ")
             << localUid);
 
     Notebook dummyNotebook;
@@ -3211,7 +3211,7 @@ void NotebookModel::onNotebookAddedOrUpdated(const Notebook & notebook)
 
 void NotebookModel::onNotebookAdded(const Notebook & notebook)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::onNotebookAdded: notebook local uid = ") << notebook.localUid());
+    QNTRACE(QStringLiteral("NotebookModel::onNotebookAdded: notebook local uid = ") << notebook.localUid());
 
     NotebookDataByLocalUid & localUidIndex = m_data.get<ByLocalUid>();
 
@@ -3282,7 +3282,7 @@ void NotebookModel::onNotebookAdded(const Notebook & notebook)
 
 void NotebookModel::onNotebookUpdated(const Notebook & notebook, NotebookDataByLocalUid::iterator it)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::onNotebookUpdated: notebook local uid = ")
+    QNTRACE(QStringLiteral("NotebookModel::onNotebookUpdated: notebook local uid = ")
             << notebook.localUid());
 
     NotebookItem notebookItemCopy;
@@ -3419,7 +3419,7 @@ void NotebookModel::onNotebookUpdated(const Notebook & notebook, NotebookDataByL
 
 void NotebookModel::onLinkedNotebookAddedOrUpdated(const LinkedNotebook & linkedNotebook)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::onLinkedNotebookAddedOrUpdated: ") << linkedNotebook);
+    QNTRACE(QStringLiteral("NotebookModel::onLinkedNotebookAddedOrUpdated: ") << linkedNotebook);
 
     if (Q_UNLIKELY(!linkedNotebook.hasGuid())) {
         QNWARNING(QStringLiteral("Can't process the addition or update of a linked notebook without guid: ")
@@ -3484,7 +3484,7 @@ NotebookModel::ModelItems::iterator NotebookModel::addNewStackModelItem(const No
                                                                         const NotebookModelItem & parentItem,
                                                                         ModelItems & modelItemsByStack)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::addNewStackModelItem: stack item = ") << stackItem);
+    QNTRACE(QStringLiteral("NotebookModel::addNewStackModelItem: stack item = ") << stackItem);
 
     NotebookModelItem newStackModelItem(NotebookModelItem::Type::Stack, Q_NULLPTR, &stackItem);
     QNTRACE(QStringLiteral("Created new stack model item: ") << newStackModelItem);
@@ -3506,7 +3506,7 @@ NotebookModel::ModelItems::iterator NotebookModel::addNewStackModelItem(const No
 
 void NotebookModel::removeItemByLocalUid(const QString & localUid)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::removeItemByLocalUid: local uid = ") << localUid);
+    QNTRACE(QStringLiteral("NotebookModel::removeItemByLocalUid: local uid = ") << localUid);
 
     NotebookDataByLocalUid & localUidIndex = m_data.get<ByLocalUid>();
     auto itemIt = localUidIndex.find(localUid);
@@ -3613,7 +3613,7 @@ void NotebookModel::notebookToItem(const Notebook & notebook, NotebookItem & ite
 
 void NotebookModel::removeModelItemFromParent(const NotebookModelItem & modelItem)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::removeModelItemFromParent: ") << modelItem);
+    QNTRACE(QStringLiteral("NotebookModel::removeModelItemFromParent: ") << modelItem);
 
     const NotebookModelItem * pParentItem = modelItem.parent();
     if (Q_UNLIKELY(!pParentItem)) {
@@ -3711,7 +3711,7 @@ void NotebookModel::updateItemRowWithRespectToSorting(const NotebookModelItem & 
 
 void NotebookModel::updatePersistentModelIndices()
 {
-    QNDEBUG(QStringLiteral("NotebookModel::updatePersistentModelIndices"));
+    QNTRACE(QStringLiteral("NotebookModel::updatePersistentModelIndices"));
 
     // Ensure any persistent model indices would be updated appropriately
     QModelIndexList indices = persistentIndexList();
@@ -3726,7 +3726,7 @@ void NotebookModel::updatePersistentModelIndices()
 
 bool NotebookModel::onAddNoteWithNotebookLocalUid(const QString & notebookLocalUid)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::onAddNoteWithNotebookLocalUid: ") << notebookLocalUid);
+    QNTRACE(QStringLiteral("NotebookModel::onAddNoteWithNotebookLocalUid: ") << notebookLocalUid);
 
     NotebookDataByLocalUid & localUidIndex = m_data.get<ByLocalUid>();
     auto it = localUidIndex.find(notebookLocalUid);
@@ -3745,7 +3745,7 @@ bool NotebookModel::onAddNoteWithNotebookLocalUid(const QString & notebookLocalU
 
 bool NotebookModel::onExpungeNoteWithNotebookLocalUid(const QString & notebookLocalUid)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::onExpungeNoteWithNotebookLocalUid: ") << notebookLocalUid);
+    QNTRACE(QStringLiteral("NotebookModel::onExpungeNoteWithNotebookLocalUid: ") << notebookLocalUid);
 
     NotebookDataByLocalUid & localUidIndex = m_data.get<ByLocalUid>();
     auto it = localUidIndex.find(notebookLocalUid);
@@ -3765,7 +3765,7 @@ bool NotebookModel::onExpungeNoteWithNotebookLocalUid(const QString & notebookLo
 
 void NotebookModel::switchDefaultNotebookLocalUid(const QString & localUid)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::switchDefaultNotebookLocalUid: ") << localUid);
+    QNTRACE(QStringLiteral("NotebookModel::switchDefaultNotebookLocalUid: ") << localUid);
 
     if (!m_defaultNotebookLocalUid.isEmpty())
     {
@@ -3804,7 +3804,7 @@ void NotebookModel::switchDefaultNotebookLocalUid(const QString & localUid)
 
 void NotebookModel::switchLastUsedNotebookLocalUid(const QString & localUid)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::setLastUsedNotebook: ") << localUid);
+    QNTRACE(QStringLiteral("NotebookModel::setLastUsedNotebook: ") << localUid);
 
     if (!m_lastUsedNotebookLocalUid.isEmpty())
     {
@@ -3843,7 +3843,7 @@ void NotebookModel::switchLastUsedNotebookLocalUid(const QString & localUid)
 
 void NotebookModel::checkAndRemoveEmptyStackItem(const NotebookModelItem & modelItem)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::checkAndRemoveEmptyStackItem: ") << modelItem);
+    QNTRACE(QStringLiteral("NotebookModel::checkAndRemoveEmptyStackItem: ") << modelItem);
 
     if (&modelItem == m_fakeRootItem) {
         QNDEBUG(QStringLiteral("Won't remove the fake root item"));
@@ -3992,7 +3992,7 @@ void NotebookModel::endRemoveNotebooks()
 
 void NotebookModel::buildNotebookLocalUidByNoteLocalUidsHash(const NoteModel & noteModel)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::buildNotebookLocalUidByNoteLocalUidsHash"));
+    QNTRACE(QStringLiteral("NotebookModel::buildNotebookLocalUidByNoteLocalUidsHash"));
 
     m_notebookLocalUidByNoteLocalUid.clear();
 
@@ -4023,7 +4023,7 @@ void NotebookModel::buildNotebookLocalUidByNoteLocalUidsHash(const NoteModel & n
 
 const NotebookModelItem & NotebookModel::findOrCreateLinkedNotebookModelItem(const QString & linkedNotebookGuid)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::findOrCreateLinkedNotebookModelItem: ") << linkedNotebookGuid);
+    QNTRACE(QStringLiteral("NotebookModel::findOrCreateLinkedNotebookModelItem: ") << linkedNotebookGuid);
 
     if (Q_UNLIKELY(!m_fakeRootItem)) {
         m_fakeRootItem = new NotebookModelItem;
@@ -4202,7 +4202,7 @@ NotebookModel::IndexId NotebookModel::idForItem(const NotebookModelItem & item) 
 
 bool NotebookModel::updateNoteCountPerNotebookIndex(const NotebookItem & item, const NotebookDataByLocalUid::iterator it)
 {
-    QNDEBUG(QStringLiteral("NotebookModel::updateNoteCountPerNotebookIndex: ") << item);
+    QNTRACE(QStringLiteral("NotebookModel::updateNoteCountPerNotebookIndex: ") << item);
 
     const QString & notebookLocalUid = item.localUid();
 

--- a/src/models/TagModel.cpp
+++ b/src/models/TagModel.cpp
@@ -94,7 +94,7 @@ TagModel::~TagModel()
 
 void TagModel::updateAccount(const Account & account)
 {
-    QNDEBUG(QStringLiteral("TagModel::updateAccount: ") << account);
+    QNTRACE(QStringLiteral("TagModel::updateAccount: ") << account);
     m_account = account;
 }
 
@@ -105,7 +105,7 @@ bool TagModel::allTagsListed() const
 
 void TagModel::favoriteTag(const QModelIndex & index)
 {
-    QNDEBUG(QStringLiteral("TagModel::favoriteTag: index: is valid = ")
+    QNTRACE(QStringLiteral("TagModel::favoriteTag: index: is valid = ")
             << (index.isValid() ? QStringLiteral("true") : QStringLiteral("false"))
             << QStringLiteral(", row = ") << index.row()
             << QStringLiteral(", column = ") << index.column()
@@ -116,7 +116,7 @@ void TagModel::favoriteTag(const QModelIndex & index)
 
 void TagModel::unfavoriteTag(const QModelIndex & index)
 {
-    QNDEBUG(QStringLiteral("TagModel::unfavoriteTag: index: is valid = ")
+    QNTRACE(QStringLiteral("TagModel::unfavoriteTag: index: is valid = ")
             << (index.isValid() ? QStringLiteral("true") : QStringLiteral("false"))
             << QStringLiteral(", row = ") << index.row()
             << QStringLiteral(", column = ") << index.column()
@@ -127,7 +127,7 @@ void TagModel::unfavoriteTag(const QModelIndex & index)
 
 bool TagModel::tagHasSynchronizedChildTags(const QString & tagLocalUid) const
 {
-    QNDEBUG(QStringLiteral("TagModel::tagHasSynchronizedChildTags: tag local uid = ") << tagLocalUid);
+    QNTRACE(QStringLiteral("TagModel::tagHasSynchronizedChildTags: tag local uid = ") << tagLocalUid);
 
     const TagDataByParentLocalUid & parentLocalUidIndex = m_data.get<ByParentLocalUid>();
     auto range = parentLocalUidIndex.equal_range(tagLocalUid);
@@ -154,7 +154,7 @@ bool TagModel::tagHasSynchronizedChildTags(const QString & tagLocalUid) const
 QString TagModel::localUidForItemName(const QString & itemName,
                                       const QString & linkedNotebookGuid) const
 {
-    QNDEBUG(QStringLiteral("TagModel::localUidForItemName: name = ") << itemName
+    QNTRACE(QStringLiteral("TagModel::localUidForItemName: name = ") << itemName
             << QStringLiteral(", linked notebook guid = ") << linkedNotebookGuid);
 
     QModelIndex index = indexForTagName(itemName, linkedNotebookGuid);
@@ -180,7 +180,7 @@ QString TagModel::localUidForItemName(const QString & itemName,
 
 QString TagModel::itemNameForLocalUid(const QString & localUid) const
 {
-    QNDEBUG(QStringLiteral("TagModel::itemNameForLocalUid: ") << localUid);
+    QNTRACE(QStringLiteral("TagModel::itemNameForLocalUid: ") << localUid);
 
     const TagDataByLocalUid & localUidIndex = m_data.get<ByLocalUid>();
     auto it = localUidIndex.find(localUid);
@@ -444,7 +444,7 @@ bool TagModel::setHeaderData(int section, Qt::Orientation orientation, const QVa
 
 bool TagModel::setData(const QModelIndex & modelIndex, const QVariant & value, int role)
 {
-    QNDEBUG(QStringLiteral("TagModel::setData: row = ") << modelIndex.row()
+    QNTRACE(QStringLiteral("TagModel::setData: row = ") << modelIndex.row()
             << QStringLiteral(", column = ") << modelIndex.column()
             << QStringLiteral(", internal id = ") << modelIndex.internalId()
             << QStringLiteral(", value = ") << value << QStringLiteral(", role = ") << role);
@@ -644,7 +644,7 @@ bool TagModel::setData(const QModelIndex & modelIndex, const QVariant & value, i
 
 bool TagModel::insertRows(int row, int count, const QModelIndex & parent)
 {
-    QNDEBUG(QStringLiteral("TagModel::insertRows: row = ") << row
+    QNTRACE(QStringLiteral("TagModel::insertRows: row = ") << row
             << QStringLiteral(", count = ") << count << QStringLiteral(", parent index: row = ")
             << parent.row() << QStringLiteral(", column = ") << parent.column()
             << QStringLiteral(", internal id = ") << parent.internalId());
@@ -727,7 +727,7 @@ bool TagModel::insertRows(int row, int count, const QModelIndex & parent)
 
 bool TagModel::removeRows(int row, int count, const QModelIndex & parent)
 {
-    QNDEBUG(QStringLiteral("TagModel::removeRows: row = ") << row
+    QNTRACE(QStringLiteral("TagModel::removeRows: row = ") << row
             << QStringLiteral(", count = ") << count << QStringLiteral(", parent index: row = ")
             << parent.row() << QStringLiteral(", column = ") << parent.column()
             << QStringLiteral(", internal id = ") << parent.internalId());
@@ -918,7 +918,7 @@ bool TagModel::removeRows(int row, int count, const QModelIndex & parent)
 
 void TagModel::sort(int column, Qt::SortOrder order)
 {
-    QNDEBUG(QStringLiteral("TagModel::sort: column = ") << column << QStringLiteral(", order = ") << order
+    QNTRACE(QStringLiteral("TagModel::sort: column = ") << column << QStringLiteral(", order = ") << order
             << QStringLiteral(" (") << (order == Qt::AscendingOrder ? QStringLiteral("ascending") : QStringLiteral("descending"))
             << QStringLiteral(")"));
 
@@ -1003,7 +1003,7 @@ QMimeData * TagModel::mimeData(const QModelIndexList & indexes) const
 bool TagModel::dropMimeData(const QMimeData * pMimeData, Qt::DropAction action,
                             int row, int column, const QModelIndex & parentIndex)
 {
-    QNDEBUG(QStringLiteral("TagModel::dropMimeData: action = ") << action
+    QNTRACE(QStringLiteral("TagModel::dropMimeData: action = ") << action
             << QStringLiteral(", row = ") << row << QStringLiteral(", column = ")
             << column << QStringLiteral(", parent index: is valid = ")
             << (parentIndex.isValid() ? QStringLiteral("true") : QStringLiteral("false"))
@@ -1199,7 +1199,7 @@ bool TagModel::dropMimeData(const QMimeData * pMimeData, Qt::DropAction action,
 
 void TagModel::onAddTagComplete(Tag tag, QUuid requestId)
 {
-    QNDEBUG(QStringLiteral("TagModel::onAddTagComplete: tag = ") << tag << QStringLiteral("\nRequest id = ") << requestId);
+    QNTRACE(QStringLiteral("TagModel::onAddTagComplete: tag = ") << tag << QStringLiteral("\nRequest id = ") << requestId);
 
     auto it = m_addTagRequestIds.find(requestId);
     if (it != m_addTagRequestIds.end()) {
@@ -1230,7 +1230,7 @@ void TagModel::onAddTagFailed(Tag tag, ErrorString errorDescription, QUuid reque
 
 void TagModel::onUpdateTagComplete(Tag tag, QUuid requestId)
 {
-    QNDEBUG(QStringLiteral("TagModel::onUpdateTagComplete: tag = ") << tag << QStringLiteral("\nRequest id = ") << requestId);
+    QNTRACE(QStringLiteral("TagModel::onUpdateTagComplete: tag = ") << tag << QStringLiteral("\nRequest id = ") << requestId);
 
     auto it = m_updateTagRequestIds.find(requestId);
     if (it != m_updateTagRequestIds.end()) {
@@ -1274,7 +1274,7 @@ void TagModel::onFindTagComplete(Tag tag, QUuid requestId)
         return;
     }
 
-    QNDEBUG(QStringLiteral("TagModel::onFindTagComplete: tag = ") << tag << QStringLiteral("\nRequest id = ") << requestId);
+    QNTRACE(QStringLiteral("TagModel::onFindTagComplete: tag = ") << tag << QStringLiteral("\nRequest id = ") << requestId);
 
     if (restoreUpdateIt != m_findTagToRestoreFailedUpdateRequestIds.end())
     {
@@ -1311,7 +1311,7 @@ void TagModel::onFindTagFailed(Tag tag, ErrorString errorDescription, QUuid requ
         return;
     }
 
-    QNDEBUG(QStringLiteral("TagModel::onFindTagFailed: tag = ") << tag << QStringLiteral("\nError description = ") << errorDescription
+    QNTRACE(QStringLiteral("TagModel::onFindTagFailed: tag = ") << tag << QStringLiteral("\nError description = ") << errorDescription
             << QStringLiteral(", request id = ") << requestId);
 
     if (restoreUpdateIt != m_findTagToRestoreFailedUpdateRequestIds.end()) {
@@ -1341,7 +1341,7 @@ void TagModel::onListTagsWithNoteLocalUidsComplete(LocalStorageManager::ListObje
         return;
     }
 
-    QNDEBUG(QStringLiteral("TagModel::onListTagsWithNoteLocalUidsComplete: flag = ") << flag << QStringLiteral(", limit = ") << limit
+    QNTRACE(QStringLiteral("TagModel::onListTagsWithNoteLocalUidsComplete: flag = ") << flag << QStringLiteral(", limit = ") << limit
             << QStringLiteral(", offset = ") << offset << QStringLiteral(", order = ") << order << QStringLiteral(", direction = ")
             << orderDirection << QStringLiteral(", linked notebook guid = ")
             << (linkedNotebookGuid.isNull() ? QStringLiteral("<null>") : linkedNotebookGuid)
@@ -1408,7 +1408,7 @@ void TagModel::onListTagsWithNoteLocalUidsFailed(LocalStorageManager::ListObject
 
 void TagModel::onExpungeTagComplete(Tag tag, QStringList expungedChildTagLocalUids, QUuid requestId)
 {
-    QNDEBUG(QStringLiteral("TagModel::onExpungeTagComplete: tag = ") << tag
+    QNTRACE(QStringLiteral("TagModel::onExpungeTagComplete: tag = ") << tag
             << QStringLiteral("\nExpunged child tag local uids: ") << expungedChildTagLocalUids.join(QStringLiteral(", "))
             << QStringLiteral(", request id = ") << requestId);
 
@@ -1445,7 +1445,7 @@ void TagModel::onGetNoteCountPerTagComplete(int noteCount, Tag tag, QUuid reques
         return;
     }
 
-    QNDEBUG(QStringLiteral("TagModel::onGetNoteCountPerTagComplete: tag = ") << tag << QStringLiteral("\nRequest id = ")
+    QNTRACE(QStringLiteral("TagModel::onGetNoteCountPerTagComplete: tag = ") << tag << QStringLiteral("\nRequest id = ")
             << requestId << QStringLiteral(", note count = ") << noteCount);
 
     Q_UNUSED(m_noteCountPerTagRequestIds.erase(it))
@@ -1524,7 +1524,7 @@ void TagModel::onGetNoteCountsPerAllTagsComplete(QHash<QString, int> noteCountsP
         return;
     }
 
-    QNDEBUG(QStringLiteral("TagModel::onGetNoteCountsPerAllTagsComplete: note counts were received for ")
+    QNTRACE(QStringLiteral("TagModel::onGetNoteCountsPerAllTagsComplete: note counts were received for ")
             << noteCountsPerTagLocalUid.size() << QStringLiteral(" tag local uids; request id = ")
             << requestId);
 
@@ -1584,7 +1584,7 @@ void TagModel::onGetNoteCountsPerAllTagsFailed(ErrorString errorDescription, QUu
 
 void TagModel::onExpungeNotelessTagsFromLinkedNotebooksComplete(QUuid requestId)
 {
-    QNDEBUG(QStringLiteral("TagModel::onExpungeNotelessTagsFromLinkedNotebooksComplete: request id = ") << requestId);
+    QNTRACE(QStringLiteral("TagModel::onExpungeNotelessTagsFromLinkedNotebooksComplete: request id = ") << requestId);
 
     TagDataByLocalUid & localUidIndex = m_data.get<ByLocalUid>();
 
@@ -1615,7 +1615,7 @@ void TagModel::onFindNotebookComplete(Notebook notebook, QUuid requestId)
         return;
     }
 
-    QNDEBUG(QStringLiteral("TagModel::onFindNotebookComplete: notebook: ") << notebook << QStringLiteral("\nRequest id = ")
+    QNTRACE(QStringLiteral("TagModel::onFindNotebookComplete: notebook: ") << notebook << QStringLiteral("\nRequest id = ")
             << requestId);
 
     Q_UNUSED(m_findNotebookRequestForLinkedNotebookGuid.right.erase(it))
@@ -1638,14 +1638,14 @@ void TagModel::onFindNotebookFailed(Notebook notebook, ErrorString errorDescript
 
 void TagModel::onUpdateNotebookComplete(Notebook notebook, QUuid requestId)
 {
-    QNDEBUG(QStringLiteral("TagModel::onUpdateNotebookComplete: local uid = ") << notebook.localUid());
+    QNTRACE(QStringLiteral("TagModel::onUpdateNotebookComplete: local uid = ") << notebook.localUid());
     Q_UNUSED(requestId)
     updateRestrictionsFromNotebook(notebook);
 }
 
 void TagModel::onExpungeNotebookComplete(Notebook notebook, QUuid requestId)
 {
-    QNDEBUG(QStringLiteral("TagModel::onExpungeNotebookComplete: local uid = ") << notebook.localUid()
+    QNTRACE(QStringLiteral("TagModel::onExpungeNotebookComplete: local uid = ") << notebook.localUid()
             << QStringLiteral(", linked notebook guid = ")
             << (notebook.hasLinkedNotebookGuid() ? notebook.linkedNotebookGuid() : QStringLiteral("<null>")));
 
@@ -1674,7 +1674,7 @@ void TagModel::onExpungeNotebookComplete(Notebook notebook, QUuid requestId)
 
 void TagModel::onAddNoteComplete(Note note, QUuid requestId)
 {
-    QNDEBUG(QStringLiteral("TagModel::onAddNoteComplete: note = ") << note
+    QNTRACE(QStringLiteral("TagModel::onAddNoteComplete: note = ") << note
             << QStringLiteral("\nRequest id = ") << requestId);
 
     if (Q_UNLIKELY(note.hasDeletionTimestamp())) {
@@ -1711,7 +1711,7 @@ void TagModel::onUpdateNoteComplete(Note note, bool updateResources, bool update
         return;
     }
 
-    QNDEBUG(QStringLiteral("TagModel::onUpdateNoteComplete: note = ") << note
+    QNTRACE(QStringLiteral("TagModel::onUpdateNoteComplete: note = ") << note
             << QStringLiteral("\nUpdate resources = ")
             << (updateResources ? QStringLiteral("true") : QStringLiteral("false"))
             << QStringLiteral(", update tags = ")
@@ -1778,7 +1778,7 @@ void TagModel::onUpdateNoteComplete(Note note, bool updateResources, bool update
 
 void TagModel::onExpungeNoteComplete(Note note, QUuid requestId)
 {
-    QNDEBUG(QStringLiteral("TagModel::onExpungeNoteComplete: note = ") << note
+    QNTRACE(QStringLiteral("TagModel::onExpungeNoteComplete: note = ") << note
             << QStringLiteral("\nRequest id = ") << requestId);
 
     if (note.hasTagLocalUids())
@@ -1824,21 +1824,21 @@ void TagModel::onExpungeNoteComplete(Note note, QUuid requestId)
 
 void TagModel::onAddLinkedNotebookComplete(LinkedNotebook linkedNotebook, QUuid requestId)
 {
-    QNDEBUG(QStringLiteral("TagModel::onAddLinkedNotebookComplete: request id = ")
+    QNTRACE(QStringLiteral("TagModel::onAddLinkedNotebookComplete: request id = ")
             << requestId << QStringLiteral(", linked notebook: ") << linkedNotebook);
     onLinkedNotebookAddedOrUpdated(linkedNotebook);
 }
 
 void TagModel::onUpdateLinkedNotebookComplete(LinkedNotebook linkedNotebook, QUuid requestId)
 {
-    QNDEBUG(QStringLiteral("TagModel::onUpdateLinkedNotebookComplete: request id = ")
+    QNTRACE(QStringLiteral("TagModel::onUpdateLinkedNotebookComplete: request id = ")
             << requestId << QStringLiteral(", linked notebook: ") << linkedNotebook);
     onLinkedNotebookAddedOrUpdated(linkedNotebook);
 }
 
 void TagModel::onExpungeLinkedNotebookComplete(LinkedNotebook linkedNotebook, QUuid requestId)
 {
-    QNDEBUG(QStringLiteral("TagModel::onExpungeLinkedNotebookComplete: request id = ")
+    QNTRACE(QStringLiteral("TagModel::onExpungeLinkedNotebookComplete: request id = ")
             << requestId << QStringLiteral(", linked notebook: ") << linkedNotebook);
 
     if (Q_UNLIKELY(!linkedNotebook.hasGuid())) {
@@ -1904,7 +1904,7 @@ void TagModel::onListAllTagsPerNoteComplete(QList<Tag> foundTags, Note note,
         return;
     }
 
-    QNDEBUG(QStringLiteral("TagModel::onListAllTagsPerNoteComplete: note = ") << note
+    QNTRACE(QStringLiteral("TagModel::onListAllTagsPerNoteComplete: note = ") << note
             << QStringLiteral("\nFlag = ") << flag << QStringLiteral(", limit = ") << limit
             << QStringLiteral(", offset = ") << offset << QStringLiteral(", order = ") << order
             << QStringLiteral(", order direction = ") << orderDirection << QStringLiteral(", request id = ")
@@ -1946,7 +1946,7 @@ void TagModel::onListAllLinkedNotebooksComplete(size_t limit, size_t offset,
         return;
     }
 
-    QNDEBUG(QStringLiteral("TagModel::onListAllLinkedNotebooksComplete: limit = ")
+    QNTRACE(QStringLiteral("TagModel::onListAllLinkedNotebooksComplete: limit = ")
             << limit << QStringLiteral(", offset = ") << offset << QStringLiteral(", order = ")
             << order << QStringLiteral(", order direction = ") << orderDirection
             << QStringLiteral(", request id = ") << requestId);
@@ -1982,7 +1982,7 @@ void TagModel::onListAllLinkedNotebooksFailed(size_t limit, size_t offset,
         return;
     }
 
-    QNDEBUG(QStringLiteral("TagModel::onListAllLinkedNotebooksFailed: limit = ") << limit
+    QNTRACE(QStringLiteral("TagModel::onListAllLinkedNotebooksFailed: limit = ") << limit
             << QStringLiteral(", offset = ") << offset << QStringLiteral(", order = ") << order
             << QStringLiteral(", order direction = ") << orderDirection << QStringLiteral(", error description = ")
             << errorDescription << QStringLiteral(", request id = ") << requestId);
@@ -1994,7 +1994,7 @@ void TagModel::onListAllLinkedNotebooksFailed(size_t limit, size_t offset,
 
 void TagModel::createConnections(LocalStorageManagerAsync & localStorageManagerAsync)
 {
-    QNDEBUG(QStringLiteral("TagModel::createConnections"));
+    QNTRACE(QStringLiteral("TagModel::createConnections"));
 
     // Local signals to localStorageManagerAsync's slots
     QObject::connect(this, QNSIGNAL(TagModel,addTag,Tag,QUuid),
@@ -2108,7 +2108,7 @@ void TagModel::createConnections(LocalStorageManagerAsync & localStorageManagerA
 
 void TagModel::requestTagsList()
 {
-    QNDEBUG(QStringLiteral("TagModel::requestTagsList: offset = ") << m_listTagsOffset);
+    QNTRACE(QStringLiteral("TagModel::requestTagsList: offset = ") << m_listTagsOffset);
 
     LocalStorageManager::ListObjectsOptions flags = LocalStorageManager::ListAll;
     LocalStorageManager::ListTagsOrder::type order = LocalStorageManager::ListTagsOrder::NoOrder;
@@ -2122,7 +2122,7 @@ void TagModel::requestTagsList()
 
 void TagModel::requestNoteCountForTag(const Tag & tag)
 {
-    QNDEBUG(QStringLiteral("TagModel::requestNoteCountForTag: ") << tag);
+    QNTRACE(QStringLiteral("TagModel::requestNoteCountForTag: ") << tag);
 
     QUuid requestId = QUuid::createUuid();
     Q_UNUSED(m_noteCountPerTagRequestIds.insert(requestId))
@@ -2132,7 +2132,7 @@ void TagModel::requestNoteCountForTag(const Tag & tag)
 
 void TagModel::requestTagsPerNote(const Note & note)
 {
-    QNDEBUG(QStringLiteral("TagModel::requestTagsPerNote: ") << note);
+    QNTRACE(QStringLiteral("TagModel::requestTagsPerNote: ") << note);
 
     QUuid requestId = QUuid::createUuid();
     Q_UNUSED(m_listTagsPerNoteRequestIds.insert(requestId))
@@ -2144,7 +2144,7 @@ void TagModel::requestTagsPerNote(const Note & note)
 
 void TagModel::requestNoteCountsPerAllTags()
 {
-    QNDEBUG(QStringLiteral("TagModel::requestNoteCountsPerAllTags"));
+    QNTRACE(QStringLiteral("TagModel::requestNoteCountsPerAllTags"));
 
     m_noteCountsPerAllTagsRequestId = QUuid::createUuid();
     Q_EMIT requestNoteCountsForAllTags(m_noteCountsPerAllTagsRequestId);
@@ -2152,7 +2152,7 @@ void TagModel::requestNoteCountsPerAllTags()
 
 void TagModel::requestLinkedNotebooksList()
 {
-    QNDEBUG(QStringLiteral("TagModel::requestLinkedNotebooksList"));
+    QNTRACE(QStringLiteral("TagModel::requestLinkedNotebooksList"));
 
     LocalStorageManager::ListLinkedNotebooksOrder::type order = LocalStorageManager::ListLinkedNotebooksOrder::NoOrder;
     LocalStorageManager::OrderDirection::type direction = LocalStorageManager::OrderDirection::Ascending;
@@ -2194,7 +2194,7 @@ void TagModel::onTagAddedOrUpdated(const Tag & tag, const QStringList * pTagNote
 
 void TagModel::onTagAdded(const Tag & tag, const QStringList * pTagNoteLocalUids)
 {
-    QNDEBUG(QStringLiteral("TagModel::onTagAdded: tag local uid = ") << tag.localUid()
+    QNTRACE(QStringLiteral("TagModel::onTagAdded: tag local uid = ") << tag.localUid()
             << QStringLiteral(", tag note local uids: ")
             << (pTagNoteLocalUids ? pTagNoteLocalUids->join(QStringLiteral(", ")) : QStringLiteral("none")));
 
@@ -2254,7 +2254,7 @@ void TagModel::onTagAdded(const Tag & tag, const QStringList * pTagNoteLocalUids
 
 void TagModel::onTagUpdated(const Tag & tag, TagDataByLocalUid::iterator it, const QStringList * pTagNoteLocalUids)
 {
-    QNDEBUG(QStringLiteral("TagModel::onTagUpdated: tag local uid = ") << tag.localUid()
+    QNTRACE(QStringLiteral("TagModel::onTagUpdated: tag local uid = ") << tag.localUid()
             << QStringLiteral(", tag note local uids: ")
             << (pTagNoteLocalUids ? pTagNoteLocalUids->join(QStringLiteral(", ")) : QStringLiteral("none")));
 
@@ -2452,7 +2452,7 @@ bool TagModel::canCreateTagItem(const TagModelItem & parentItem) const
 
 void TagModel::updateRestrictionsFromNotebook(const Notebook & notebook)
 {
-    QNDEBUG(QStringLiteral("TagModel::updateRestrictionsFromNotebook: local uid = ") << notebook.localUid()
+    QNTRACE(QStringLiteral("TagModel::updateRestrictionsFromNotebook: local uid = ") << notebook.localUid()
             << QStringLiteral(", linked notebook guid = ")
             << (notebook.hasLinkedNotebookGuid() ? notebook.linkedNotebookGuid() : QStringLiteral("<null>")));
 
@@ -2480,14 +2480,14 @@ void TagModel::updateRestrictionsFromNotebook(const Notebook & notebook)
     }
 
     m_tagRestrictionsByLinkedNotebookGuid[notebook.linkedNotebookGuid()] = restrictions;
-    QNDEBUG(QStringLiteral("Set restrictions for tags from linked notebook with guid ") << notebook.linkedNotebookGuid()
+    QNTRACE(QStringLiteral("Set restrictions for tags from linked notebook with guid ") << notebook.linkedNotebookGuid()
             << QStringLiteral(": can create tags = ") << (restrictions.m_canCreateTags ? QStringLiteral("true") : QStringLiteral("false"))
             << QStringLiteral(", can update tags = ") << (restrictions.m_canUpdateTags ? QStringLiteral("true") : QStringLiteral("false")));
 }
 
 void TagModel::onLinkedNotebookAddedOrUpdated(const LinkedNotebook & linkedNotebook)
 {
-    QNDEBUG(QStringLiteral("TagModel::onLinkedNotebookAddedOrUpdated: ") << linkedNotebook);
+    QNTRACE(QStringLiteral("TagModel::onLinkedNotebookAddedOrUpdated: ") << linkedNotebook);
 
     if (Q_UNLIKELY(!linkedNotebook.hasGuid())) {
         QNWARNING(QStringLiteral("Can't process the addition or update of a linked notebook without guid: ")
@@ -2550,7 +2550,7 @@ void TagModel::onLinkedNotebookAddedOrUpdated(const LinkedNotebook & linkedNoteb
 
 const TagModelItem * TagModel::itemForId(const IndexId id) const
 {
-    QNDEBUG(QStringLiteral("TagModel::itemForId: ") << id);
+    QNTRACE(QStringLiteral("TagModel::itemForId: ") << id);
 
     auto localUidIt = m_indexIdToLocalUidBimap.left.find(id);
     if (localUidIt == m_indexIdToLocalUidBimap.left.end())
@@ -2758,7 +2758,7 @@ QModelIndex TagModel::indexForTagName(const QString & tagName, const QString & l
 
 QModelIndex TagModel::indexForLinkedNotebookGuid(const QString & linkedNotebookGuid) const
 {
-    QNDEBUG(QStringLiteral("TagModel::indexForLinkedNotebookGuid: linked notebook guid = ")
+    QNTRACE(QStringLiteral("TagModel::indexForLinkedNotebookGuid: linked notebook guid = ")
             << linkedNotebookGuid);
 
     auto it = m_modelItemsByLinkedNotebookGuid.find(linkedNotebookGuid);
@@ -2773,7 +2773,7 @@ QModelIndex TagModel::indexForLinkedNotebookGuid(const QString & linkedNotebookG
 
 QModelIndex TagModel::promote(const QModelIndex & itemIndex)
 {
-    QNDEBUG(QStringLiteral("TagModel::promote"));
+    QNTRACE(QStringLiteral("TagModel::promote"));
 
     if (!itemIndex.isValid()) {
         REPORT_ERROR(QT_TR_NOOP("Can't promote the tag: model index is invalid"));
@@ -2932,7 +2932,7 @@ QModelIndex TagModel::promote(const QModelIndex & itemIndex)
 
 QModelIndex TagModel::demote(const QModelIndex & itemIndex)
 {
-    QNDEBUG(QStringLiteral("TagModel::demote"));
+    QNTRACE(QStringLiteral("TagModel::demote"));
 
     if (!itemIndex.isValid()) {
         REPORT_ERROR(QT_TR_NOOP("Can't demote the tag: model index is invalid"));
@@ -3117,7 +3117,7 @@ QModelIndexList TagModel::persistentIndexes() const
 
 QModelIndex TagModel::moveToParent(const QModelIndex & index, const QString & parentTagName)
 {
-    QNDEBUG(QStringLiteral("TagModel::moveToParent: parent tag name = ") << parentTagName);
+    QNTRACE(QStringLiteral("TagModel::moveToParent: parent tag name = ") << parentTagName);
 
     if (Q_UNLIKELY(parentTagName.isEmpty())) {
         return removeFromParent(index);
@@ -3239,7 +3239,7 @@ QModelIndex TagModel::moveToParent(const QModelIndex & index, const QString & pa
 
 QModelIndex TagModel::removeFromParent(const QModelIndex & index)
 {
-    QNDEBUG(QStringLiteral("TagModel::removeFromParent"));
+    QNTRACE(QStringLiteral("TagModel::removeFromParent"));
 
     const TagModelItem * pModelItem = itemForId(static_cast<IndexId>(index.internalId()));
     if (Q_UNLIKELY(!pModelItem)) {
@@ -3296,7 +3296,7 @@ QModelIndex TagModel::removeFromParent(const QModelIndex & index)
 
 QStringList TagModel::tagNames(const QString & linkedNotebookGuid) const
 {
-    QNDEBUG(QStringLiteral("TagModel::tagNames: linked notebook guid = ") << linkedNotebookGuid
+    QNTRACE(QStringLiteral("TagModel::tagNames: linked notebook guid = ") << linkedNotebookGuid
             << QStringLiteral(" (null = ") << (linkedNotebookGuid.isNull() ? QStringLiteral("true") : QStringLiteral("false"))
             << QStringLiteral(", empty = ") << (linkedNotebookGuid.isEmpty() ? QStringLiteral("true") : QStringLiteral("false"))
             << QStringLiteral(")"));
@@ -3322,7 +3322,7 @@ QStringList TagModel::tagNames(const QString & linkedNotebookGuid) const
 QModelIndex TagModel::createTag(const QString & tagName, const QString & parentTagName,
                                 const QString & linkedNotebookGuid, ErrorString & errorDescription)
 {
-    QNDEBUG(QStringLiteral("TagModel::createTag: tag name = ") << tagName << QStringLiteral(", parent tag name = ")
+    QNTRACE(QStringLiteral("TagModel::createTag: tag name = ") << tagName << QStringLiteral(", parent tag name = ")
             << parentTagName << QStringLiteral(", linked notebook guid = ") << linkedNotebookGuid);
 
     if (tagName.isEmpty()) {
@@ -3502,7 +3502,7 @@ bool TagModel::hasSynchronizableChildren(const TagModelItem * pModelItem) const
 
 void TagModel::mapChildItems()
 {
-    QNDEBUG(QStringLiteral("TagModel::mapChildItems"));
+    QNTRACE(QStringLiteral("TagModel::mapChildItems"));
 
     for(auto it = m_modelItemsByLocalUid.begin(),
         end = m_modelItemsByLocalUid.end(); it != end; ++it)
@@ -3610,7 +3610,7 @@ QString TagModel::nameForNewTag(const QString & linkedNotebookGuid) const
 
 void TagModel::removeItemByLocalUid(const QString & localUid)
 {
-    QNDEBUG(QStringLiteral("TagModel::removeItemByLocalUid: ") << localUid);
+    QNTRACE(QStringLiteral("TagModel::removeItemByLocalUid: ") << localUid);
 
     TagDataByLocalUid & localUidIndex = m_data.get<ByLocalUid>();
     auto itemIt = localUidIndex.find(localUid);
@@ -3677,7 +3677,7 @@ void TagModel::removeItemByLocalUid(const QString & localUid)
 
 void TagModel::removeModelItemFromParent(const TagModelItem & item)
 {
-    QNDEBUG(QStringLiteral("TagModel::removeModelItemFromParent: ") << item);
+    QNTRACE(QStringLiteral("TagModel::removeModelItemFromParent: ") << item);
 
     const TagModelItem * pParentItem = item.parent();
     if (Q_UNLIKELY(!pParentItem)) {
@@ -3703,7 +3703,7 @@ void TagModel::removeModelItemFromParent(const TagModelItem & item)
 
 int TagModel::rowForNewItem(const TagModelItem & parentItem, const TagModelItem & newItem) const
 {
-    QNDEBUG(QStringLiteral("TagModel::rowForNewItem: new item = ") << newItem
+    QNTRACE(QStringLiteral("TagModel::rowForNewItem: new item = ") << newItem
             << QStringLiteral(", parent item = ") << parentItem);
 
     if (m_sortedColumn != Columns::Name) {
@@ -3730,13 +3730,13 @@ int TagModel::rowForNewItem(const TagModelItem & parentItem, const TagModelItem 
         row = static_cast<int>(std::distance(children.constBegin(), it));
     }
 
-    QNDEBUG(QStringLiteral("Appropriate row = ") << row);
+    QNTRACE(QStringLiteral("Appropriate row = ") << row);
     return row;
 }
 
 void TagModel::updateItemRowWithRespectToSorting(const TagModelItem & item)
 {
-    QNDEBUG(QStringLiteral("TagModel::updateItemRowWithRespectToSorting: item = ") << item);
+    QNTRACE(QStringLiteral("TagModel::updateItemRowWithRespectToSorting: item = ") << item);
 
     if (m_sortedColumn != Columns::Name) {
         QNDEBUG(QStringLiteral("Won't sort on column ") << m_sortedColumn);
@@ -3793,7 +3793,7 @@ void TagModel::updateItemRowWithRespectToSorting(const TagModelItem & item)
 
 void TagModel::updatePersistentModelIndices()
 {
-    QNDEBUG(QStringLiteral("TagModel::updatePersistentModelIndices"));
+    QNTRACE(QStringLiteral("TagModel::updatePersistentModelIndices"));
 
     // Ensure any persistent model indices would be updated appropriately
     QModelIndexList indices = persistentIndexList();
@@ -3808,7 +3808,7 @@ void TagModel::updatePersistentModelIndices()
 
 void TagModel::updateTagInLocalStorage(const TagItem & item)
 {
-    QNDEBUG(QStringLiteral("TagModel::updateTagInLocalStorage: local uid = ") << item.localUid());
+    QNTRACE(QStringLiteral("TagModel::updateTagInLocalStorage: local uid = ") << item.localUid());
 
     Tag tag;
 
@@ -3932,7 +3932,7 @@ void TagModel::endRemoveTags()
 
 const TagModelItem & TagModel::findOrCreateLinkedNotebookModelItem(const QString & linkedNotebookGuid)
 {
-    QNDEBUG(QStringLiteral("TagModel::findOrCreateLinkedNotebookModelItem: ") << linkedNotebookGuid);
+    QNTRACE(QStringLiteral("TagModel::findOrCreateLinkedNotebookModelItem: ") << linkedNotebookGuid);
 
     if (Q_UNLIKELY(!m_fakeRootItem)) {
         m_fakeRootItem = new TagModelItem;
@@ -3951,7 +3951,7 @@ const TagModelItem & TagModel::findOrCreateLinkedNotebookModelItem(const QString
         return linkedNotebookModelItemIt.value();
     }
 
-    QNDEBUG(QStringLiteral("Found no existing model item corresponding to linked notebook guid ")
+    QNTRACE(QStringLiteral("Found no existing model item corresponding to linked notebook guid ")
             << linkedNotebookGuid << QStringLiteral(", will create one"));
 
     const TagLinkedNotebookRootItem * pLinkedNotebookItem = Q_NULLPTR;
@@ -4068,7 +4068,7 @@ void TagModel::checkAndRemoveEmptyLinkedNotebookRootItem(const TagModelItem & mo
         return;
     }
 
-    QNDEBUG(QStringLiteral("Removed the last child from the linked notebook root item, will remove that item as well"));
+    QNTRACE(QStringLiteral("Removed the last child from the linked notebook root item, will remove that item as well"));
     removeModelItemFromParent(modelItem);
 
     QString linkedNotebookGuid = modelItem.tagLinkedNotebookItem()->linkedNotebookGuid();

--- a/src/views/NoteListView.cpp
+++ b/src/views/NoteListView.cpp
@@ -50,13 +50,13 @@ NoteListView::NoteListView(QWidget * parent) :
 
 void NoteListView::setNotebookItemView(NotebookItemView * pNotebookItemView)
 {
-    QNDEBUG(QStringLiteral("NoteListView::setNotebookItemView"));
+    QNTRACE(QStringLiteral("NoteListView::setNotebookItemView"));
     m_pNotebookItemView = pNotebookItemView;
 }
 
 void NoteListView::setAutoSelectNoteOnNextAddition()
 {
-    QNDEBUG(QStringLiteral("NoteListView::setAutoSelectNoteOnNextAddition"));
+    QNTRACE(QStringLiteral("NoteListView::setAutoSelectNoteOnNextAddition"));
     m_shouldSelectFirstNoteOnNextNoteAddition = true;
 }
 
@@ -145,7 +145,7 @@ void NoteListView::setCurrentAccount(const Account & account)
 
 void NoteListView::setCurrentNoteByLocalUid(QString noteLocalUid)
 {
-    QNDEBUG(QStringLiteral("NoteListView::setCurrentNoteByLocalUid: ") << noteLocalUid);
+    QNTRACE(QStringLiteral("NoteListView::setCurrentNoteByLocalUid: ") << noteLocalUid);
 
     NoteFilterModel * pNoteFilterModel = qobject_cast<NoteFilterModel*>(model());
     if (Q_UNLIKELY(!pNoteFilterModel)) {
@@ -182,7 +182,7 @@ void NoteListView::setShowNoteThumbnailsState(bool showThumbnailsForAllNotes, co
 
 void NoteListView::selectNotesByLocalUids(const QStringList & noteLocalUids)
 {
-    QNDEBUG(QStringLiteral("NoteListView::selectNotesByLocalUids: ") << noteLocalUids.join(QStringLiteral(", ")));
+    QNTRACE(QStringLiteral("NoteListView::selectNotesByLocalUids: ") << noteLocalUids.join(QStringLiteral(", ")));
 
     NoteFilterModel * pNoteFilterModel = qobject_cast<NoteFilterModel*>(model());
     if (Q_UNLIKELY(!pNoteFilterModel)) {
@@ -248,7 +248,7 @@ void NoteListView::dataChanged(const QModelIndex & topLeft, const QModelIndex & 
 
 void NoteListView::rowsAboutToBeRemoved(const QModelIndex & parent, int start, int end)
 {
-    QNDEBUG(QStringLiteral("NoteListView::rowsAboutToBeRemoved: start = ") << start << QStringLiteral(", end = ") << end);
+    QNTRACE(QStringLiteral("NoteListView::rowsAboutToBeRemoved: start = ") << start << QStringLiteral(", end = ") << end);
 
     QModelIndex current = currentIndex();
     if (current.isValid())
@@ -272,7 +272,7 @@ void NoteListView::rowsAboutToBeRemoved(const QModelIndex & parent, int start, i
 
 void NoteListView::rowsInserted(const QModelIndex & parent, int start, int end)
 {
-    QNDEBUG(QStringLiteral("NoteListView::rowsInserted: start = ") << start << QStringLiteral(", end = ") << end);
+    QNTRACE(QStringLiteral("NoteListView::rowsInserted: start = ") << start << QStringLiteral(", end = ") << end);
 
     QListView::rowsInserted(parent, start, end);
 
@@ -373,7 +373,7 @@ void NoteListView::onEditNoteAction()
 
 void NoteListView::onMoveToOtherNotebookAction()
 {
-    QNDEBUG(QStringLiteral("NoteListView::onMoveToOtherNotebookAction"));
+    QNTRACE(QStringLiteral("NoteListView::onMoveToOtherNotebookAction"));
 
     QAction * pAction = qobject_cast<QAction*>(sender());
     if (Q_UNLIKELY(!pAction)) {

--- a/src/widgets/AbstractFilterByModelItemWidget.cpp
+++ b/src/widgets/AbstractFilterByModelItemWidget.cpp
@@ -42,7 +42,7 @@ AbstractFilterByModelItemWidget::AbstractFilterByModelItemWidget(const QString &
 
 void AbstractFilterByModelItemWidget::switchAccount(const Account & account, ItemModel * pItemModel)
 {
-    QNDEBUG(QStringLiteral("AbstractFilterByModelItemWidget::switchAccount: ") << account);
+    QNDEBUG(QStringLiteral("AbstractFilterByModelItemWidget::switchAccount: ") << account.name());
 
     if (!m_pItemModel.isNull() && (m_pItemModel.data() != pItemModel)) {
         QObject::disconnect(m_pItemModel.data(), QNSIGNAL(ItemModel,notifyAllItemsListed),
@@ -448,7 +448,7 @@ void AbstractFilterByModelItemWidget::onModelReady()
 void AbstractFilterByModelItemWidget::persistFilteredItems()
 {
     QNDEBUG(QStringLiteral("AbstractFilterByModelItemWidget::persistFilteredItems: account = ")
-            << m_account);
+            << m_account.name());
 
     if (m_account.isEmpty()) {
         QNDEBUG(QStringLiteral("The account is empty, nothing to persist"));

--- a/src/widgets/NoteTagsWidget.cpp
+++ b/src/widgets/NoteTagsWidget.cpp
@@ -63,7 +63,7 @@ void NoteTagsWidget::setTagModel(TagModel * pTagModel)
 
 void NoteTagsWidget::setCurrentNoteAndNotebook(const Note & note, const Notebook & notebook)
 {
-    QNDEBUG(QStringLiteral("NoteTagsWidget::setCurrentNoteAndNotebook: note local uid = ") << note
+    QNTRACE(QStringLiteral("NoteTagsWidget::setCurrentNoteAndNotebook: note local uid = ") << note
             << QStringLiteral(", notebook: ") << notebook);
 
     bool changed = (note.localUid() != m_currentNote.localUid());
@@ -152,7 +152,7 @@ void NoteTagsWidget::clear()
 
 void NoteTagsWidget::onTagRemoved(QString tagName)
 {
-    QNDEBUG(QStringLiteral("NoteTagsWidget::onTagRemoved: tag name = ") << tagName);
+    QNTRACE(QStringLiteral("NoteTagsWidget::onTagRemoved: tag name = ") << tagName);
 
     if (Q_UNLIKELY(m_currentNote.localUid().isEmpty())) {
         QNDEBUG(QStringLiteral("No current note is set, ignoring the tag removal event"));
@@ -218,7 +218,7 @@ void NoteTagsWidget::onTagRemoved(QString tagName)
 
 void NoteTagsWidget::onNewTagNameEntered()
 {
-    QNDEBUG(QStringLiteral("NoteTagsWidget::onNewTagNameEntered"));
+    QNTRACE(QStringLiteral("NoteTagsWidget::onNewTagNameEntered"));
 
     NewListItemLineEdit * pNewItemLineEdit = qobject_cast<NewListItemLineEdit*>(sender());
     if (Q_UNLIKELY(!pNewItemLineEdit)) {
@@ -343,7 +343,7 @@ void NoteTagsWidget::onNewTagNameEntered()
 
 void NoteTagsWidget::onAllTagsListed()
 {
-    QNDEBUG(QStringLiteral("NoteTagsWidget::onAllTagsListed"));
+    QNTRACE(QStringLiteral("NoteTagsWidget::onAllTagsListed"));
 
     if (m_pTagModel.isNull()) {
         return;
@@ -367,7 +367,7 @@ void NoteTagsWidget::onUpdateNoteComplete(Note note, bool updateResources,
         return;
     }
 
-    QNDEBUG(QStringLiteral("NoteTagsWidget::onUpdateNoteComplete: note local uid = ") << note.localUid()
+    QNTRACE(QStringLiteral("NoteTagsWidget::onUpdateNoteComplete: note local uid = ") << note.localUid()
             << QStringLiteral(", request id = ") << requestId);
 
     if (updateResources) {
@@ -585,7 +585,7 @@ void NoteTagsWidget::onUpdateNotebookComplete(Notebook notebook, QUuid requestId
         return;
     }
 
-    QNDEBUG(QStringLiteral("NoteTagsWidget::onUpdateNotebookComplete: notebook = ") << notebook
+    QNTRACE(QStringLiteral("NoteTagsWidget::onUpdateNotebookComplete: notebook = ") << notebook
             << QStringLiteral("\nRequest id = ") << requestId);
 
     bool changed = false;
@@ -627,7 +627,7 @@ void NoteTagsWidget::onExpungeNotebookComplete(Notebook notebook, QUuid requestI
         return;
     }
 
-    QNDEBUG(QStringLiteral("NoteTagsWidget::onExpungeNotebookComplete: notebook = ") << notebook
+    QNTRACE(QStringLiteral("NoteTagsWidget::onExpungeNotebookComplete: notebook = ") << notebook
             << QStringLiteral("\nRequest id = ") << requestId);
 
     clear();
@@ -696,7 +696,7 @@ void NoteTagsWidget::onUpdateTagComplete(Tag tag, QUuid requestId)
 
 void NoteTagsWidget::onExpungeTagComplete(Tag tag, QStringList expungedChildTagLocalUids, QUuid requestId)
 {
-    QNDEBUG(QStringLiteral("NoteTagsWidget::onExpungeTagComplete: tag = ") << tag
+    QNTRACE(QStringLiteral("NoteTagsWidget::onExpungeTagComplete: tag = ") << tag
             << QStringLiteral("\nRequest id = ") << requestId);
 
     Q_UNUSED(requestId)
@@ -738,7 +738,7 @@ void NoteTagsWidget::clearLayout(const bool skipNewTagWidget)
 
 void NoteTagsWidget::updateLayout()
 {
-    QNDEBUG(QStringLiteral("NoteTagsWidget::updateLayout"));
+    QNTRACE(QStringLiteral("NoteTagsWidget::updateLayout"));
 
     const QString & noteLocalUid = m_currentNote.localUid();
     if (Q_UNLIKELY(noteLocalUid.isEmpty())) {
@@ -852,7 +852,7 @@ void NoteTagsWidget::updateLayout()
 
 void NoteTagsWidget::addTagIconToLayout()
 {
-    QNDEBUG(QStringLiteral("NoteTagsWidget::addTagIconToLayout"));
+    QNTRACE(QStringLiteral("NoteTagsWidget::addTagIconToLayout"));
 
     QPixmap tagIconImage(QStringLiteral(":/tag/tag.png"));
     QLabel * pTagIconLabel = new QLabel(this);
@@ -863,7 +863,7 @@ void NoteTagsWidget::addTagIconToLayout()
 
 void NoteTagsWidget::addNewTagWidgetToLayout()
 {
-    QNDEBUG(QStringLiteral("NoteTagsWidget::addNewTagWidgetToLayout"));
+    QNTRACE(QStringLiteral("NoteTagsWidget::addNewTagWidgetToLayout"));
 
     const int numItems = m_pLayout->count();
     for(int i = 0; i < numItems; ++i)
@@ -916,7 +916,7 @@ void NoteTagsWidget::addNewTagWidgetToLayout()
 
 void NoteTagsWidget::removeNewTagWidgetFromLayout()
 {
-    QNDEBUG(QStringLiteral("NoteTagsWidget::removeNewTagWidgetFromLayout"));
+    QNTRACE(QStringLiteral("NoteTagsWidget::removeNewTagWidgetFromLayout"));
 
     int numItems = m_pLayout->count();
     for(int i = 0; i < numItems; ++i)
@@ -940,7 +940,7 @@ void NoteTagsWidget::removeNewTagWidgetFromLayout()
 
 void NoteTagsWidget::removeTagWidgetFromLayout(const QString & tagLocalUid)
 {
-    QNDEBUG(QStringLiteral("NoteTagsWidget::removeTagWidgetFromLayout: tag local uid = ") << tagLocalUid);
+    QNTRACE(QStringLiteral("NoteTagsWidget::removeTagWidgetFromLayout: tag local uid = ") << tagLocalUid);
 
     int tagIndex = m_lastDisplayedTagLocalUids.indexOf(tagLocalUid);
     if (tagIndex < 0) {
@@ -989,7 +989,7 @@ void NoteTagsWidget::removeTagWidgetFromLayout(const QString & tagLocalUid)
 
 void NoteTagsWidget::setTagItemsRemovable(const bool removable)
 {
-    QNDEBUG(QStringLiteral("NoteTagsWidget::setTagItemsRemovable: removable = ")
+    QNTRACE(QStringLiteral("NoteTagsWidget::setTagItemsRemovable: removable = ")
             << (removable ? QStringLiteral("true") : QStringLiteral("false")));
 
     int numItems = m_pLayout->count();
@@ -1011,7 +1011,7 @@ void NoteTagsWidget::setTagItemsRemovable(const bool removable)
 
 void NoteTagsWidget::createConnections(LocalStorageManagerAsync & localStorageManagerAsync)
 {
-    QNDEBUG(QStringLiteral("NoteTagsWidget::createConnections"));
+    QNTRACE(QStringLiteral("NoteTagsWidget::createConnections"));
 
     // Connect local storage signals to local slots
     QObject::connect(&localStorageManagerAsync, QNSIGNAL(LocalStorageManagerAsync,updateNoteComplete,Note,bool,bool,QUuid),
@@ -1062,7 +1062,7 @@ bool NoteTagsWidget::isActive() const
 
 QStringList NoteTagsWidget::tagNames() const
 {
-    QNDEBUG(QStringLiteral("NoteTagsWidget::tagNames"));
+    QNTRACE(QStringLiteral("NoteTagsWidget::tagNames"));
 
     if (!isActive()) {
         QNDEBUG(QStringLiteral("NoteTagsWidget is not active"));


### PR DESCRIPTION
This is next iteration at log verbosity adjustment - #196
It changes the delimiter for sourcefile:line from " @ " to ":" (there for it should be merged together with similar PR on libquentier repository).
At selected places log level is changed from DEBUG to TRACE.
The idea is to make DEBUG level more usable - still very verbose - but manageable.
Although I taken care, it can happen that as some place I reduced to much - but I will readjust in next iterations. Normally I would do one PR for feature, but here I suggest more iterations.

For some sync error I increased the level.

At few places I reduced "account" to "account.name()" which seems reasonable.

On few model classes I basically changed most logging from DEBUG to TRACE as this generates too much output.

This is still far from finished, but I believe its improvement.