### PR TITLE
Fixed working of storageDir command line parameter

### DIFF
--- a/src/initialization/Initialize.cpp
+++ b/src/initialization/Initialize.cpp
@@ -53,6 +53,12 @@ void parseCommandLine(int argc, char *argv[], ParseCommandLineResult & result)
 
 int initialize(QuentierApplication & app, const CommandLineParser::CommandLineOptions & cmdOptions)
 {
+    // we need to check for override of "storage dir path" command line option before doing anything else
+    int errCode = processStorageDirCommandLineOption(cmdOptions);
+    if (!errCode) {
+        return errCode;
+    }
+
     // Initialize logging
     QUENTIER_INITIALIZE_LOGGING();
     QUENTIER_SET_MIN_LOG_LEVEL(Info);
@@ -80,19 +86,25 @@ int initialize(QuentierApplication & app, const CommandLineParser::CommandLineOp
 
     setupStartQuentierAtLogin();
 
+    // here rest of command line arguments is processed
     return processCommandLineOptions(cmdOptions);
 }
 
-int processCommandLineOptions(const CommandLineParser::CommandLineOptions & cmdOptions)
-{
-    typedef CommandLineParser::CommandLineOptions CmdOptions;
+typedef CommandLineParser::CommandLineOptions CmdOptions;
 
+int processStorageDirCommandLineOption(const CommandLineParser::CommandLineOptions & cmdOptions)
+{
     CmdOptions::const_iterator storageDirIt = cmdOptions.find(QStringLiteral("storageDir"));
     if (storageDirIt != cmdOptions.constEnd()) {
         QString storageDir = storageDirIt.value().toString();
         qputenv(LIBQUENTIER_PERSISTENCE_STORAGE_PATH, storageDir.toLocal8Bit());
     }
+    return 0;
+}
 
+
+int processCommandLineOptions(const CommandLineParser::CommandLineOptions & cmdOptions)
+{
     CmdOptions::const_iterator accountIt = cmdOptions.find(QStringLiteral("account"));
     if (accountIt != cmdOptions.constEnd())
     {

--- a/src/initialization/Initialize.cpp
+++ b/src/initialization/Initialize.cpp
@@ -54,9 +54,9 @@ void parseCommandLine(int argc, char *argv[], ParseCommandLineResult & result)
 int initialize(QuentierApplication & app, const CommandLineParser::CommandLineOptions & cmdOptions)
 {
     // we need to check for override of "storage dir path" command line option before doing anything else
-    int errCode = processStorageDirCommandLineOption(cmdOptions);
-    if (!errCode) {
-        return errCode;
+    int result = processStorageDirCommandLineOption(cmdOptions);
+    if (result) {
+        return result;
     }
 
     // Initialize logging

--- a/src/initialization/Initialize.h
+++ b/src/initialization/Initialize.h
@@ -45,6 +45,22 @@ void parseCommandLine(int argc, char *argv[], ParseCommandLineResult & result);
 
 int initialize(QuentierApplication & app, const CommandLineParser::CommandLineOptions & cmdOptions);
 
+/**
+ * Checks and processes "storageDir" command line options. This is special because it changes
+ * the base path there app is searching for other things. Therefore it *must* be processed
+ * very early. Other options may need be checked later.
+ *
+ * @param options Parsed command line arguments.
+ * @return 0=OK, anything else is error code
+ */
+int processStorageDirCommandLineOption(const CommandLineParser::CommandLineOptions & options);
+
+/**
+ * Checks and processes rest of command line options. See processStorageDirCommandLineOption().
+ *
+ * @param options Parsed command line arguments.
+ * @return 0=OK, anything else is error code
+ */
 int processCommandLineOptions(const CommandLineParser::CommandLineOptions & options);
 
 } // namespace quentier

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,9 +55,10 @@ int main(int argc, char *argv[])
     app.setApplicationName(QStringLiteral("Quentier"));
     app.setQuitOnLastWindowClosed(false);
 
-    int res = initialize(app, parseCmdResult.m_cmdOptions);
-    if (res != 0) {
-        return res;
+    int result = initialize(app, parseCmdResult.m_cmdOptions);
+    if (result != 0) {
+        return result;
+        return result;
     }
 
     QScopedPointer<MainWindow> pMainWindow;


### PR DESCRIPTION
Issue #203

As I was not 100% sure about reordering of processing all command line parameters (I needed to process storageDir before initializing anything else) I divided processing of command line params into two parts.
First only processes storageDir.
Second function stays where it was before and processes rest.
